### PR TITLE
Remove blank after #!

### DIFF
--- a/app/browser/buffer.py
+++ b/app/browser/buffer.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright (C) 2018 Andy Stewart

--- a/app/imageviewer/buffer.py
+++ b/app/imageviewer/buffer.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright (C) 2018 Andy Stewart

--- a/app/videoplayer/buffer.py
+++ b/app/videoplayer/buffer.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright (C) 2018 Andy Stewart

--- a/core/buffer.py
+++ b/core/buffer.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright (C) 2018 Andy Stewart

--- a/core/eaf.py
+++ b/core/eaf.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright (C) 2018 Andy Stewart

--- a/core/fake_key_event.py
+++ b/core/fake_key_event.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright (C) 2018 Andy Stewart

--- a/core/view.py
+++ b/core/view.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright (C) 2018 Andy Stewart

--- a/core/xutils.py
+++ b/core/xutils.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright (C) 2011 ~ 2014 Andy Stewart


### PR DESCRIPTION
There is a rumor that a few earlier Unix versions (particularly 4.2BSD derivatives) require us to add a blank. This claim turns out to be incorrect according to https://www.in-ulm.de/~mascheck/various/shebang/#blankrequired