### PR TITLE
对docker进行了一些小调整

### DIFF
--- a/docker/.emacs
+++ b/docker/.emacs
@@ -1,2 +1,0 @@
-(setq load-path (cons "/emacs-application-framework" load-path))
-(require 'eaf)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,12 @@
 FROM base/archlinux
 
 RUN pacman -Syy && \
-    pacman -S git nss emacs pkg-config dbus gcc make python python-pip  --noconfirm && \
+    pacman -S git emacs  nss python python-pip python-dbus  --noconfirm && \
     yes|pacman -Scc 
 
 RUN pip install --upgrade pip
 
-RUN pip install PyMuPDF grip qrcode xlib pyqt5 dbus-python && rm -rf /root/.cache
+RUN pip install PyMuPDF grip qrcode xlib pyqt5 && rm -rf /root/.cache
 
 RUN git clone --depth=1 https://github.com/manateelazycat/emacs-application-framework
 
@@ -17,7 +17,7 @@ ENV LANG=zh_CN.UTF-8
 
 USER eaf
 
-COPY .emacs /home/eaf/
+# COPY .emacs /home/eaf/
 
 
-ENTRYPOINT ["emacs"]
+CMD ["emacs","-L","/emacs-application-framework","--eval","(require 'eaf)"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,12 +4,20 @@ If you prefer to run linux in a container, you can use below command to build an
 
 ### Build
 ```Shell
-docker build -t eaf -f Dockerfile.arch .
+docker build -t eaf  .
 ```
 
 ### Run
 ```Shell
 xhost +local:root # WARN: this comes with security issues
 
-docker run -e DISPLAY -e DBUS_SESSION_BUS_ADDRESS --rm -it -v /tmp/.X11-unix/:/tmp/.X11-unix -v /run/user/$(id -u)/:/run/user/1000/ -v ~/.Xauthority:/home/eaf/.Xauthority   eaf
+docker run -e DISPLAY -e DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus --rm -it -v /tmp/.X11-unix/:/tmp/.X11-unix -v /run/user/$(id -u)/:/run/user/1000/ -v ~/.Xauthority:/home/eaf/.Xauthority   eaf
+```
+You can also reuse your own Emacs configuration in the container:
+
+```Shell
+xhost +local:root # WARN: this comes with security issues
+
+# mount the Emacs configuration into the container
+docker run -e DISPLAY -e DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus --rm -it -v /tmp/.X11-unix/:/tmp/.X11-unix -v /run/user/$(id -u)/:/run/user/1000/ -v ~/.Xauthority:/home/eaf/.Xauthority -v ~/.emacs.d:/home/eaf/.emacs.d  eaf
 ```


### PR DESCRIPTION
1.用回python-dbus，因为比较来看用python-dbus要比dbus-python构建出来的image少大约200M空间
2.直接通过Emacs命令行参数加载eaf，这样允许使用者挂载自己的配置到容器中
3.改名默认的Dockerfile，方便build image