### PR TITLE
Use elisp to handle keybinding

### DIFF
--- a/core/browser_buffer.py
+++ b/core/browser_buffer.py
@@ -42,6 +42,11 @@ class BrowserBuffer(Buffer):
     def scroll(self, scroll_direction, scroll_type):
         webview_scroll(self, scroll_direction, scroll_type)
 
+    def eval_code(self, code):
+        eval(code, {
+            "self": self.buffer_widget,
+        })
+
     def send_keystroke(self, keystroke):
         if keystroke == "M-f":
             self.buffer_widget.forward()

--- a/eaf-browser.el
+++ b/eaf-browser.el
@@ -1,0 +1,42 @@
+(defun eaf-buffer-eval (code)
+  (interactive)
+  (eaf-call "eval_code" buffer-id code))
+
+(defun eaf-eval-js (js)
+  (interactive)
+  (eaf-call "eval_code" buffer-id
+            (format "self.web_page.runJavaScript(\"%s\")" js)))
+
+(defun eaf-zoom-out()
+  (interactive)
+  (eaf-buffer-eval "self.zoom_out()"))
+
+(defun eaf-zoom-in()
+  (interactive)
+  (eaf-buffer-eval "self.zoom_in()"))
+
+(defun eaf-next-line ()
+  (interactive)
+  (eaf-eval-js "window.scrollBy(0, 50)"))
+
+(defun eaf-previous-line ()
+  (interactive)
+  (eaf-eval-js "window.scrollBy(0, -50)"))
+
+(defun eaf-beginning-of-buffer ()
+  (interactive)
+  (eaf-eval-js "scrollTo(0, 0)"))
+
+(defun eaf-end-of-buffer ()
+  (interactive)
+    (eaf-eval-js "scrollBy(0,document.body.scrollHeight)"))
+
+(defun eaf-browser-keybind()
+  (local-set-key (kbd "C-=") 'eaf-zoom-in)
+  (local-set-key (kbd "C--") 'eaf-zoom-out)
+  (local-set-key (kbd "M-<") 'eaf-beginning-of-buffer)
+  (local-set-key (kbd "M->") 'eaf-end-of-buffer)
+  (local-set-key (kbd "C-n") 'eaf-next-line)
+  (local-set-key (kbd "C-p") 'eaf-previous-line))
+
+(add-hook 'eaf-mode-hook 'eaf-browser-keybind)

--- a/eaf.py
+++ b/eaf.py
@@ -240,6 +240,11 @@ class EAF(dbus.service.Object):
         if buffer_id in self.buffer_dict:
             self.buffer_dict[buffer_id].send_keystroke(keystroke)
 
+    @dbus.service.method(EAF_DBUS_NAME, in_signature="ss", out_signature="")
+    def eval_code(self, buffer_id, code):
+        if buffer_id in self.buffer_dict:
+            self.buffer_dict[buffer_id].eval_code(code)
+
     @dbus.service.method(EAF_DBUS_NAME, in_signature="sss", out_signature="")
     def handle_input_message(self, buffer_id, callback_type, callback_result):
         for buffer in list(self.buffer_dict.values()):


### PR DESCRIPTION
After adding a "eval_code" dbus method, and add a naive
implement to core/browser_buffer.py,
We can operate webview by elisp in the native way.

The eaf-browser.el offer an example, the simple 60 line of code
have offer a more better user experience.

And there have many feature can be implement by this way, which
don't need modify any core of EAF code.