### PR TITLE
Create eaf-open-demo, eaf-open-camera, eaf-open-qutebrowser functions

### DIFF
--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -24,10 +24,10 @@ Python is a perfect language to develop Qt program and it can call pretty much i
 
 ## Let me run hello word
 ```
-M-x eaf-open
+M-x eaf-open-demo
 ```
 
-    Then type "eaf-demo" as input, will pop hello world window in emacs like below:
+    This will pop hello world window in emacs like below:
 
 | Demo                                                  |
 | :--------:                                            |

--- a/eaf.el
+++ b/eaf.el
@@ -547,55 +547,64 @@ We need calcuate render allocation to make sure no black border around render co
       (progn (setq app-name "browser")
              (unless (or (string-prefix-p "http://" url) (string-prefix-p "https://" url))
                (setq url (concat "http://" url)))
-  (eaf-open url "browser" arguments))
+             (eaf-open url "browser" arguments))
     (when (string= app-name "browser")
       (message (format "EAF: %s is an invalid URL." url)))))
 
+(defun eaf-open-demo ()
+  "Open EAF demo screen to verify that EAF is working properly."
+  (interactive)
+  (eaf-open "eaf-demo" "demo"))
+
+(defun eaf-open-camera ()
+  "Open EAF camera application."
+  (interactive)
+  (eaf-open "eaf-camera" "camera"))
+
+(defun eaf-open-qutebrowser ()
+  "Open EAF Qutebrowser application."
+  (interactive)
+  (eaf-open "eaf-qutebrowser" "qutebrowser"))
+
 (defun eaf-open (url &optional app-name arguments)
-  "Open an EAF application with URL, optional APP-NAME and ARGUMENTS."
+  "Open an EAF application with URL, optional APP-NAME and ARGUMENTS.
+
+When called interactively, URL accepts a file that can be opened by EAF."
   (interactive "FOpen with EAF: ")
   ;; Try to set app-name along with url if app-name is unset.
-  (unless app-name
-    (cond ((string-equal url "eaf-demo")
-           (setq app-name "demo"))
-          ((string-equal url "eaf-camera")
-           (setq app-name "camera"))
-          ((string-equal url "eaf-qutebrowser")
-           (setq app-name "qutebrowser"))
-          ((file-exists-p url)
-           ;;(when (and (not app-name) (file-exists-p url))
-           (setq url (expand-file-name url))
-           (setq extension-name (file-name-extension url))
-           (cond ((member extension-name '("pdf" "xps" "oxps" "cbz" "epub" "fb2" "fbz"))
-                  (setq app-name "pdfviewer"))
-                 ((member extension-name '("md"))
-                  ;; Try get user's github token if `eaf-grip-token' is nil.
-                  (if eaf-grip-token
-                      (setq arguments eaf-grip-token)
-                    (setq arguments (read-string "Fill your own github token (or set `eaf-grip-token' with token string): ")))
-                  ;; Split window to show file and previewer.
-                  (eaf-split-preview-windows)
-                  (setq app-name "markdownpreviewer"))
-                 ((member extension-name '("jpg" "png" "bmp"))
-                  (setq app-name "imageviewer"))
-                 ((member extension-name '("avi" "rmvb" "ogg" "mp4"))
-                  (setq app-name "videoplayer"))
-                 ((member extension-name '("html"))
-                  (setq url (concat "file://" url))
-                  (setq app-name "browser"))
-                 ((member extension-name '("org"))
-                  ;; Find file first, because `find-file' will trigger `kill-buffer' operation.
-                  (save-excursion
-                    (find-file url)
-                    (with-current-buffer (buffer-name)
-                      (org-html-export-to-html)))
-                  ;; Add file name to `eaf-org-file-list' after command `find-file'.
+  (when (and (not app-name) (file-exists-p url))
+    (setq url (expand-file-name url))
+    (setq extension-name (file-name-extension url))
+    (cond ((member extension-name '("pdf" "xps" "oxps" "cbz" "epub" "fb2" "fbz"))
+           (setq app-name "pdfviewer"))
+          ((member extension-name '("md"))
+           ;; Try get user's github token if `eaf-grip-token' is nil.
+           (if eaf-grip-token
+               (setq arguments eaf-grip-token)
+             (setq arguments (read-string "Fill your own github token (or set `eaf-grip-token' with token string): ")))
+           ;; Split window to show file and previewer.
+           (eaf-split-preview-windows)
+           (setq app-name "markdownpreviewer"))
+          ((member extension-name '("jpg" "png" "bmp"))
+           (setq app-name "imageviewer"))
+          ((member extension-name '("avi" "rmvb" "ogg" "mp4"))
+           (setq app-name "videoplayer"))
+          ((member extension-name '("html"))
+           (setq url (concat "file://" url))
+           (setq app-name "browser"))
+          ((member extension-name '("org"))
+           ;; Find file first, because `find-file' will trigger `kill-buffer' operation.
+           (save-excursion
+             (find-file url)
+             (with-current-buffer (buffer-name)
+               (org-html-export-to-html)))
+           ;; Add file name to `eaf-org-file-list' after command `find-file'.
 
-                  (unless (member url eaf-org-file-list)
-                    (push url eaf-org-file-list))
-                  ;; Split window to show file and previewer.
-                  (eaf-split-preview-windows)
-                  (setq app-name "orgpreviewer"))))))
+           (unless (member url eaf-org-file-list)
+             (push url eaf-org-file-list))
+           ;; Split window to show file and previewer.
+           (eaf-split-preview-windows)
+           (setq app-name "orgpreviewer"))))
 
   (unless arguments
     (setq arguments ""))


### PR DESCRIPTION
Take out:
```
(cond ((string-equal url "eaf-demo")
           (setq app-name "demo"))
          ((string-equal url "eaf-camera")
           (setq app-name "camera"))
          ((string-equal url "eaf-qutebrowser")
           (setq app-name "qutebrowser"))
```
Because

- eaf-open is interactive "F. It is impossible to pass url as "eaf-demo" or "eaf-camera" or "eaf-qutebrowser" interactively when using counsel. It only accepts a valid file as input.

- To stay consistent with the function eaf-open-browser. It makes sense to use special functions for opening a browser and camera instead of opening files. Normal file interactions stay with eaf-open function itself.