### PR TITLE
Give option to dired-find-alternate-file

### DIFF
--- a/eaf.el
+++ b/eaf.el
@@ -131,6 +131,10 @@
 
 (defvar eaf-http-proxy-port "")
 
+(defvar eaf-find-alternate-file-in-dired nil
+  "If non-nil, when calling `eaf-file-open-in-dired', EAF unrecognizable files will be opened
+by `dired-find-alternate-file'. Otherwise they will be opened normally with `dired-find-file'.")
+
 (defcustom eaf-name "*eaf*"
   "Name of eaf buffer."
   :type 'string
@@ -682,8 +686,9 @@ When called interactively, URL accepts a file that can be opened by EAF."
            (eaf-open file "imageviewer"))
           ((member extension-name '("avi" "rmvb" "ogg" "mp4"))
            (eaf-open file "videoplayer"))
-          (t
-           (find-file file)))))
+          (eaf-find-alternate-file-in-dired
+           (dired-find-alternate-file))
+          (t (dired-find-file)))))
 
 ;;;;;;;;;;;;;;;;;;;; Utils ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defun eaf-get-view-info ()


### PR DESCRIPTION
It will allow better navigating and opening files using EAF through the dired buffer

Because I like to use `dired-find-alternate-file` instead of `dired-find-file` like this
```
;; Reuse same dired buffer, to prevent numerous buffers while navigating in dired
(put 'dired-find-alternate-file 'disabled nil)

(setq eaf-find-alternate-file-in-dired t)
(global-set-key [remap dired-find-alternate-file] #'eaf-file-open-in-dired)
(add-hook 'dired-mode-hook . (lambda ()
                               (local-set-key (kbd "<mouse-2>") #'dired-find-alternate-file)
                               (local-set-key (kbd "RET") #'dired-find-alternate-file)
                               (local-set-key (kbd "^")
                                              (lambda () (interactive) (find-alternate-file "..")))))
```