### PR TITLE
Fix: if display two pages, don't work on first page.

### DIFF
--- a/app/pdf-viewer/buffer.py
+++ b/app/pdf-viewer/buffer.py
@@ -422,10 +422,11 @@ class PdfViewerWidget(QWidget):
 
                 # computer absolute coordinate of page
                 x = int((pos.x() - render_x) * 1.0 / self.scale)
-                if last_page_index - start_page_index == 1:
+                if pos.y() + self.scroll_offset < (start_page_index + 1) * self.scale * self.page_height:
                     page_offset = self.scroll_offset - start_page_index * self.scale * self.page_height
                 else:
-                    page_offset = self.scroll_offset - (start_page_index + 1) * self.scale * self.page_height
+                    # if display two pages, pos.y() will add page_padding
+                    page_offset = self.scroll_offset - (start_page_index + 1) * self.scale * self.page_height - self.page_padding
                 y = int((pos.y() + page_offset) * 1.0 / self.scale)
                 word_offset = 10 # 10 pixel is enough for word intersect operation
                 draw_rect = fitz.Rect(x, y, x + word_offset, y + word_offset)


### PR DESCRIPTION
use page index, translate function don't work on first page if display two pages. Therefore determine the page offset based on position.