### PR TITLE
New API, eaf-setq on the Emacs side, custom save camera directory

### DIFF
--- a/app/camera/buffer.py
+++ b/app/camera/buffer.py
@@ -46,7 +46,7 @@ class AppBuffer(Buffer):
         self.buffer_widget.camera.start()
 
     def take_photo(self):
-        self.buffer_widget.take_photo()
+        self.buffer_widget.take_photo(self.emacs_var_dict["eaf-camera-save-path"])
 
 class CameraWidget(QWidget):
 
@@ -83,11 +83,16 @@ class CameraWidget(QWidget):
         self.camera.setCaptureMode(QCamera.CaptureStillImage)
         self.camera.start()
 
-    def take_photo(self):
-        photo_path = os.path.join(str(Path.home()), "EAF_Camera_Photo_" + time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(int(time.time()))))
-
+    def take_photo(self, camera_save_path):
         image_capture = QCameraImageCapture(self.camera)
-        image_capture.capture(photo_path)
+        try:
+            save_path = str(Path(os.path.expanduser(camera_save_path)))
+            photo_path = os.path.join(save_path, "EAF_Camera_Photo_" + time.strftime("%Y-%m-%d_%H:%M:%S", time.localtime(int(time.time()))))
+            image_capture.capture(photo_path)
+        except:
+            save_path = str(Path(os.path.expanduser("~/Downloads")))
+            photo_path = os.path.join(save_path, "EAF_Camera_Photo_" + time.strftime("%Y-%m-%d_%H:%M:%S", time.localtime(int(time.time()))))
+            image_capture.capture(photo_path)
 
         self.message_to_emacs.emit("Save photo at: " + photo_path)
 

--- a/core/buffer.py
+++ b/core/buffer.py
@@ -152,6 +152,7 @@ class Buffer(QGraphicsScene):
         self.progressbar_progress = 0
         self.progressbar_color = QColor(233, 129, 35, 255)
         self.progressbar_height = 2
+        self.emacs_var_dict = {}
 
     def drawForeground(self, painter, rect):
         if self.draw_progressbar:

--- a/eaf.py
+++ b/eaf.py
@@ -142,6 +142,9 @@ class EAF(dbus.service.Object):
         # Send message to emacs.
         app_buffer.input_message.connect(self.input_message)
 
+        # Get variables defined in emacs
+        self.get_emacs_var()
+
         # Handle buffer close request.
         app_buffer.close_buffer.connect(self.request_kill_buffer)
 
@@ -249,7 +252,13 @@ class EAF(dbus.service.Object):
             if buffer.buffer_id == buffer_id:
                 buffer.handle_input_message(callback_type, callback_result)
 
-    @dbus.service.signal("com.lazycat.eaf")
+    @dbus.service.method(EAF_DBUS_NAME, in_signature="ss", out_signature="")
+    def store_emacs_var(self, var_name, var_value):
+        for buffer in list(self.buffer_dict.values()):
+            buffer.emacs_var_dict[var_name] = var_value
+            # self.message_to_emacs("EAF Python: Storing " + var_name + " with " + buffer.emacs_var_dict[var_name])
+
+    @dbus.service.signal(EAF_DBUS_NAME)
     def focus_emacs_buffer(self, message):
         pass
 
@@ -283,6 +292,10 @@ class EAF(dbus.service.Object):
 
     @dbus.service.signal("com.lazycat.eaf")
     def message_to_emacs(self, message):
+        pass
+
+    @dbus.service.signal(EAF_DBUS_NAME)
+    def get_emacs_var(self):
         pass
 
     def save_buffer_session(self, buf):


### PR DESCRIPTION
`(eaf-setq sym val)` allows a brand new way to customize variables from the Emacs side that sends the variable with its values to the Python side whenever EAF starts. 
Now, `eaf-setq` gives the interface for users on the Emacs side to customize Emacs lisp that can affect Python directly, this opens a new door to EAF.

I've created an illustration of how it could work with the save camera photo feature you added few days ago. The user simply needs to
```
(eaf-setq 'eaf-camera-save-path "/new/path/")
```
in their Emacs `.emacs` config to customize the directory to save EAF Camera photos!

We now can python behaviour without actually modifying Python code!

With this capability, this also _potentially_ gives the ability for #82 , to modify EAF keybindings within Emacs Lisp, without touching the Python side.