### PR TITLE
Allow to execute app cmds programmatically

### DIFF
--- a/eaf.el
+++ b/eaf.el
@@ -391,7 +391,17 @@ We need calcuate render allocation to make sure no black border around render co
           (random (expt 16 4))
           (random (expt 16 4))))
 
-(defun eaf-dummy-function (sym)
+(defun eaf-execute-app-cmd (cmd &optional buf)
+  "Execute app CMD.
+
+If BUF is given it should be the eaf buffer for the command
+otherwise it is assumed that the current buffer is the eaf
+buffer."
+  (with-current-buffer (or buf (current-buffer))
+    (let ((this-command cmd))
+      (call-interactively cmd))))
+
+
 (defun eaf-dummy-function (sym key)
   "Define an alias from SYM to a dummy function that acts as a placeholder."
   (defalias sym (lambda nil

--- a/eaf.el
+++ b/eaf.el
@@ -419,7 +419,7 @@ Please ONLY use `eaf-bind-key' to edit EAF keybindings!"
                   ;; `pre-command-hook'
                   (when (and (eq this-command sym)
                              (not (equal (this-command-keys-vector) key)))
-                    (eaf-monitor-key-event (symbol-name sym))))))
+                    (eaf-call "execute_function" buffer-id (symbol-name sym))))))
 
 (defun eaf-gen-keybinding-map (keybinding)
   "Configure the eaf-mode-map from KEYBINDING, one of the eaf-*-keybinding variables."
@@ -528,12 +528,11 @@ Please ONLY use `eaf-bind-key' to edit EAF keybindings!"
              (eaf-call "update_buffer_with_url" "app.orgpreviewer.buffer" (buffer-file-name) "")
              (message (format "export %s to html" (buffer-file-name))))))))
 
-(defun eaf-monitor-key-event (&optional cmd-name)
+(defun eaf-monitor-key-event ()
   "Monitor key events during EAF process."
   (ignore-errors
     (let* ((key (this-command-keys-vector))
-           (key-command (or cmd-name
-                            (symbol-name (key-binding key))))
+           (key-command (symbol-name (key-binding key)))
            (key-desc (key-description key)))
 
       ;; Uncomment for debug.
@@ -546,8 +545,7 @@ Please ONLY use `eaf-bind-key' to edit EAF keybindings!"
         ;; Call function on the Python side if matched key in the keybinding.
         ((eaf-identify-key-in-app key-command buffer-app-name)
          (eaf-call "execute_function" buffer-id
-                   (or cmd-name
-                       (cdr (assoc key-desc (eaf-get-app-bindings buffer-app-name))))))
+                   (cdr (assoc key-desc (eaf-get-app-bindings buffer-app-name)))))
         ;; Send key to Python side if key-command is single character key.
         ((or (equal key-command "self-insert-command")
              (equal key-command "completion-select-if-within-overlay")

--- a/eaf.el
+++ b/eaf.el
@@ -1,4 +1,4 @@
-;;; eaf.el --- Emacs application framework
+;;; eaf.el --- Emacs application framework  -*- lexical-binding: t; -*-
 
 ;; Filename: eaf.el
 ;; Description: Emacs application framework


### PR DESCRIPTION
This enables to invoke python commands like `scroll_down` and others from `M-x` and similar. A new function for invoking python commands from lisp code was also added which can be used like:

    (eaf-execute-app-cmd 'scroll_down "eaf-buffer-name...")

