### PR TITLE
New keymap features and fix some key problems

### DIFF
--- a/eaf.el
+++ b/eaf.el
@@ -450,7 +450,9 @@ Please ONLY use `eaf-bind-key' to edit EAF keybindings!"
          (eaf-buffer (generate-new-buffer (truncate-string-to-width file-or-command-name eaf-title-length))))
     (with-current-buffer eaf-buffer
       (eaf-mode)
-      (make-local-variable 'emulation-mode-map-alists)
+      ;; copy default value in case user already has bindings there
+      (setq-local emulation-mode-map-alists
+                  (default-value 'emulation-mode-map-alists))
       (push (list (cons t eaf-mode-map))
             emulation-mode-map-alists))
     eaf-buffer))

--- a/eaf.el
+++ b/eaf.el
@@ -95,6 +95,7 @@
 
 (defvar eaf-mode-map*
   (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-h m") 'eaf-describe-bindings)
     (define-key map [remap describe-bindings] 'eaf-describe-bindings)
     map)
   "Keymap for default bindings available in all apps.")

--- a/eaf.el
+++ b/eaf.el
@@ -95,7 +95,7 @@
 
 (defvar eaf-mode-map*
   (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "C-h m") 'eaf-describe-bindings)
+    (define-key map [remap describe-bindings] 'eaf-describe-bindings)
     map)
   "Keymap for default bindings available in all apps.")
 

--- a/eaf.el
+++ b/eaf.el
@@ -93,10 +93,24 @@
   "Eaf mode hook."
   :type 'hook)
 
-(defvar eaf-mode-map
+(defvar eaf-mode-map*
   (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-h m") 'eaf-describe-bindings)
     map)
-  "Keymap used by `eaf-mode'.")
+  "Keymap for default bindings available in all apps.")
+
+(defvar eaf-mode-map nil
+  "Keymap used by `eaf-mode'.
+
+Don't modify this map directly. To bind keys for all apps use
+`eaf-mode-map*' and to bind keys for individual apps use
+`eaf-bind-key'.")
+
+(defun eaf-describe-bindings ()
+  "Like `describe-bindings' for eaf buffers."
+  (interactive)
+  (let ((eaf-mode-map (current-local-map)))
+    (call-interactively 'describe-mode)))
 
 (defvar-local eaf--buffer-id nil
   "Internal id used by eaf app.")
@@ -420,7 +434,8 @@ Please ONLY use `eaf-bind-key' to edit EAF keybindings!"
                    do (let ((dummy (intern (format "eaf-%s" fun))))
                         (eaf-dummy-function dummy fun key)
                         (define-key map (kbd key) dummy))
-                   finally return map))))
+                   finally return (prog1 map
+                                    (set-keymap-parent map eaf-mode-map*))))))
 
 (defun eaf-get-app-bindings (app-name)
   (symbol-value

--- a/eaf.el
+++ b/eaf.el
@@ -110,7 +110,8 @@ Don't modify this map directly. To bind keys for all apps use
 (defun eaf-describe-bindings ()
   "Like `describe-bindings' for eaf buffers."
   (interactive)
-  (let ((eaf-mode-map (current-local-map)))
+  (let ((emulation-mode-map-alists nil)
+        (eaf-mode-map (current-local-map)))
     (call-interactively 'describe-mode)))
 
 (defvar-local eaf--buffer-id nil
@@ -448,7 +449,10 @@ Please ONLY use `eaf-bind-key' to edit EAF keybindings!"
   (let* ((file-or-command-name (substring input-content (string-match "[^/]*/?$" input-content)))
          (eaf-buffer (generate-new-buffer (truncate-string-to-width file-or-command-name eaf-title-length))))
     (with-current-buffer eaf-buffer
-      (eaf-mode))
+      (eaf-mode)
+      (make-local-variable 'emulation-mode-map-alists)
+      (push (list (cons t eaf-mode-map))
+            emulation-mode-map-alists))
     eaf-buffer))
 
 (defun eaf-identify-key-in-app (key-command app-name)


### PR DESCRIPTION
This adds a default map which can be used for bindings which you can use in all apps. This also adds a command bound in this map to fix problem with `C-h m` (as discussed in #117)  when using multiple apps in parallel.

If you want to bind other keys which should be available for all apps use:

    (define-key eaf-mode-map* ...)

