### PR TITLE
Add bookmark feature for eaf browser

### DIFF
--- a/core/browser_buffer.py
+++ b/core/browser_buffer.py
@@ -91,8 +91,7 @@ class BrowserBuffer(Buffer):
     def scroll_to_bottom(self):
         self.eval_js("window.scrollBy(0, document.body.scrollHeight)")
 
-    def set_bookmark(self):
-        url = self.buffer_widget.web_page.executeJavaScript("window.location.href;")
-        self.buffer_widget.set_emacs_var.emit("eaf--browser-current-url", url)
+    def get_bookmark(self):
+        return self.buffer_widget.web_page.executeJavaScript("window.location.href;")
 
 

--- a/core/browser_buffer.py
+++ b/core/browser_buffer.py
@@ -90,3 +90,9 @@ class BrowserBuffer(Buffer):
 
     def scroll_to_bottom(self):
         self.eval_js("window.scrollBy(0, document.body.scrollHeight)")
+
+    def set_url_for_bookmark(self):
+        url = self.buffer_widget.web_page.executeJavaScript("window.location.href;")
+        self.buffer_widget.set_emacs_var.emit("eaf--browser-current-url", url)
+
+

--- a/core/browser_buffer.py
+++ b/core/browser_buffer.py
@@ -91,7 +91,7 @@ class BrowserBuffer(Buffer):
     def scroll_to_bottom(self):
         self.eval_js("window.scrollBy(0, document.body.scrollHeight)")
 
-    def set_url_for_bookmark(self):
+    def set_bookmark(self):
         url = self.buffer_widget.web_page.executeJavaScript("window.location.href;")
         self.buffer_widget.set_emacs_var.emit("eaf--browser-current-url", url)
 

--- a/core/buffer.py
+++ b/core/buffer.py
@@ -271,5 +271,5 @@ class Buffer(QGraphicsScene):
     def update_settings(self):
         pass
 
-    def set_bookmark(self):
+    def get_bookmark(self):
         pass

--- a/core/buffer.py
+++ b/core/buffer.py
@@ -272,4 +272,4 @@ class Buffer(QGraphicsScene):
         pass
 
     def get_bookmark(self):
-        pass
+        return ""

--- a/core/buffer.py
+++ b/core/buffer.py
@@ -267,3 +267,6 @@ class Buffer(QGraphicsScene):
 
     def update_settings(self):
         pass
+
+    def set_bookmark(self):
+        pass

--- a/eaf.el
+++ b/eaf.el
@@ -329,6 +329,25 @@ For now only eaf browser app is supported."
     (cond ((equal app "browser")
            (eaf-open-url (cdr (assq 'filename bookmark)))))))
 
+(defun eaf-browser-open-bookmark ()
+  "Command to open or create eaf bookmarks with completion."
+  (interactive)
+  (bookmark-maybe-load-default-file)
+  (let* ((bookmarks (cl-remove-if-not
+                     (lambda (entry)
+                       (bookmark-prop-get entry 'eaf-app))
+                     bookmark-alist))
+         (names (mapcar #'car bookmarks))
+         (cand (completing-read "Eaf bookmark: " bookmarks)))
+    (cond ((member cand names)
+           (bookmark-jump cand))
+          (t
+           (unless (derived-mode-p 'eaf-mode)
+             (user-error "Not in an eaf buffer"))
+           ;; create new one
+           (bookmark-set cand)))))
+
+
 (defun eaf-call (method &rest args)
   (apply #'dbus-call-method
          :session                   ; use the session (not system) bus

--- a/eaf.el
+++ b/eaf.el
@@ -304,8 +304,8 @@ Any new app should add the its name and the corresponding
 keybinding variable to this list.")
 
 
-(defvar eaf--browser-current-url nil)
-(defvar-local eaf--full-title nil)
+(defvar eaf--bookmark-link nil)
+(defvar-local eaf--bookmark-title nil)
 
 (defun eaf--bookmark-make-record ()
   "Create a eaf bookmark.
@@ -313,15 +313,15 @@ keybinding variable to this list.")
 The bookmark will try to recreate eaf buffer session.
 For now only eaf browser app is supported."
   (cond ((equal eaf--buffer-app-name "browser")
-         ;; set `eaf--browser-current-url'
+         ;; set `eaf--bookmark-link'
          (eaf-call "execute_function" eaf--buffer-id
                    "set_bookmark")
          (let ((bookmark `((handler . eaf--bookmark-restore)
                            (eaf-app . "browser")
-                           (defaults . ,(list eaf--full-title))
+                           (defaults . ,(list eaf--bookmark-title))
                            ;; not a filename but this shows url in bookmark-list
                            ;; which is nice
-                           (filename . ,eaf--browser-current-url))))
+                           (filename . ,eaf--bookmark-link))))
            bookmark))))
 
 (defun eaf--bookmark-restore (bookmark)
@@ -342,8 +342,8 @@ For now only eaf browser app is supported."
          (cand (completing-read "Eaf bookmark: "
                                 bookmarks
                                 nil nil nil nil
-                                (unless (member eaf--full-title names)
-                                  (format "+%s" eaf--full-title)))))
+                                (unless (member eaf--bookmark-title names)
+                                  (format "+%s" eaf--bookmark-title)))))
     (cond ((member cand names)
            (bookmark-jump cand))
           (t
@@ -744,7 +744,7 @@ Use it as (eaf-bind-key var key eaf-app-keybinding)"
             (when (and
                    (derived-mode-p 'eaf-mode)
                    (equal eaf--buffer-id bid))
-              (setq-local eaf--full-title title)
+              (setq-local eaf--bookmark-title title)
               (rename-buffer (truncate-string-to-width title eaf-title-length))
               (throw 'find-buffer t))))))))
 

--- a/eaf.el
+++ b/eaf.el
@@ -342,7 +342,8 @@ For now only eaf browser app is supported."
          (cand (completing-read "Eaf bookmark: "
                                 bookmarks
                                 nil nil nil nil
-                                (unless (member eaf--bookmark-title names)
+                                (unless (or (member eaf--bookmark-title names)
+                                            (not (derived-mode-p 'eaf-mode)))
                                   (format "+%s" eaf--bookmark-title)))))
     (cond ((member cand names)
            (bookmark-jump cand))

--- a/eaf.el
+++ b/eaf.el
@@ -339,12 +339,19 @@ For now only eaf browser app is supported."
                        (bookmark-prop-get entry 'eaf-app))
                      bookmark-alist))
          (names (mapcar #'car bookmarks))
-         (cand (completing-read "Eaf bookmark: " bookmarks)))
+         (cand (completing-read "Eaf bookmark: "
+                                bookmarks
+                                nil nil nil nil
+                                (unless (member eaf--browser-full-title names)
+                                  (format "+%s" eaf--browser-full-title)))))
     (cond ((member cand names)
            (bookmark-jump cand))
           (t
            (unless (derived-mode-p 'eaf-mode)
              (user-error "Not in an eaf buffer"))
+
+           (when (string-match "\\`\\+" cand)
+             (setq cand (replace-match "" nil nil cand)))
            ;; create new one
            (bookmark-set cand)))))
 

--- a/eaf.el
+++ b/eaf.el
@@ -304,7 +304,6 @@ Any new app should add the its name and the corresponding
 keybinding variable to this list.")
 
 
-(defvar eaf--bookmark-link nil)
 (defvar-local eaf--bookmark-title nil)
 
 (defun eaf--bookmark-make-record ()
@@ -313,15 +312,13 @@ keybinding variable to this list.")
 The bookmark will try to recreate eaf buffer session.
 For now only eaf browser app is supported."
   (cond ((equal eaf--buffer-app-name "browser")
-         ;; set `eaf--bookmark-link'
-         (eaf-call "execute_function" eaf--buffer-id
-                   "set_bookmark")
          (let ((bookmark `((handler . eaf--bookmark-restore)
                            (eaf-app . "browser")
                            (defaults . ,(list eaf--bookmark-title))
                            ;; not a filename but this shows url in bookmark-list
                            ;; which is nice
-                           (filename . ,eaf--bookmark-link))))
+                           (filename . ,(eaf-call "call_function"
+                                                  eaf--buffer-id "get_bookmark")))))
            bookmark))))
 
 (defun eaf--bookmark-restore (bookmark)

--- a/eaf.el
+++ b/eaf.el
@@ -97,6 +97,7 @@
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-h m") 'eaf-describe-bindings)
     (define-key map [remap describe-bindings] 'eaf-describe-bindings)
+    (define-key map (kbd "C-c b") 'eaf-browser-open-bookmark)
     map)
   "Keymap for default bindings available in all apps.")
 

--- a/eaf.el
+++ b/eaf.el
@@ -315,7 +315,7 @@ For now only eaf browser app is supported."
   (cond ((equal eaf--buffer-app-name "browser")
          ;; set `eaf--browser-current-url'
          (eaf-call "execute_function" eaf--buffer-id
-                   "set_url_for_bookmark")
+                   "set_bookmark")
          (let ((bookmark `((handler . eaf--bookmark-restore)
                            (eaf-app . "browser")
                            (defaults . ,(list eaf--full-title))

--- a/eaf.el
+++ b/eaf.el
@@ -305,7 +305,7 @@ keybinding variable to this list.")
 
 
 (defvar eaf--browser-current-url nil)
-(defvar eaf--browser-full-title nil)
+(defvar-local eaf--browser-full-title nil)
 
 (defun eaf--bookmark-make-record ()
   "Create a eaf bookmark.
@@ -744,7 +744,7 @@ Use it as (eaf-bind-key var key eaf-app-keybinding)"
             (when (and
                    (derived-mode-p 'eaf-mode)
                    (equal eaf--buffer-id bid))
-              (setq eaf--browser-full-title title)
+              (setq-local eaf--browser-full-title title)
               (rename-buffer (truncate-string-to-width title eaf-title-length))
               (throw 'find-buffer t))))))))
 

--- a/eaf.el
+++ b/eaf.el
@@ -316,7 +316,7 @@ For now only eaf browser app is supported."
          (eaf-call "execute_function" eaf--buffer-id
                    "set_url_for_bookmark")
          (let ((bookmark `((handler . eaf--bookmark-restore)
-                           (app . "browser")
+                           (eaf-app . "browser")
                            (defaults . ,(list eaf--browser-full-title))
                            ;; not a filename but this shows url in bookmark-list
                            ;; which is nice
@@ -325,7 +325,7 @@ For now only eaf browser app is supported."
 
 (defun eaf--bookmark-restore (bookmark)
   "Restore eaf buffer according to BOOKMARK."
-  (let ((app (cdr (assq 'app bookmark))))
+  (let ((app (cdr (assq 'eaf-app bookmark))))
     (cond ((equal app "browser")
            (eaf-open-url (cdr (assq 'filename bookmark)))))))
 

--- a/eaf.el
+++ b/eaf.el
@@ -97,7 +97,7 @@
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-h m") 'eaf-describe-bindings)
     (define-key map [remap describe-bindings] 'eaf-describe-bindings)
-    (define-key map (kbd "C-c b") 'eaf-browser-open-bookmark)
+    (define-key map (kbd "C-c b") 'eaf-open-bookmark)
     map)
   "Keymap for default bindings available in all apps.")
 
@@ -305,7 +305,7 @@ keybinding variable to this list.")
 
 
 (defvar eaf--browser-current-url nil)
-(defvar-local eaf--browser-full-title nil)
+(defvar-local eaf--full-title nil)
 
 (defun eaf--bookmark-make-record ()
   "Create a eaf bookmark.
@@ -318,7 +318,7 @@ For now only eaf browser app is supported."
                    "set_url_for_bookmark")
          (let ((bookmark `((handler . eaf--bookmark-restore)
                            (eaf-app . "browser")
-                           (defaults . ,(list eaf--browser-full-title))
+                           (defaults . ,(list eaf--full-title))
                            ;; not a filename but this shows url in bookmark-list
                            ;; which is nice
                            (filename . ,eaf--browser-current-url))))
@@ -330,7 +330,7 @@ For now only eaf browser app is supported."
     (cond ((equal app "browser")
            (eaf-open-url (cdr (assq 'filename bookmark)))))))
 
-(defun eaf-browser-open-bookmark ()
+(defun eaf-open-bookmark ()
   "Command to open or create eaf bookmarks with completion."
   (interactive)
   (bookmark-maybe-load-default-file)
@@ -342,8 +342,8 @@ For now only eaf browser app is supported."
          (cand (completing-read "Eaf bookmark: "
                                 bookmarks
                                 nil nil nil nil
-                                (unless (member eaf--browser-full-title names)
-                                  (format "+%s" eaf--browser-full-title)))))
+                                (unless (member eaf--full-title names)
+                                  (format "+%s" eaf--full-title)))))
     (cond ((member cand names)
            (bookmark-jump cand))
           (t
@@ -744,7 +744,7 @@ Use it as (eaf-bind-key var key eaf-app-keybinding)"
             (when (and
                    (derived-mode-p 'eaf-mode)
                    (equal eaf--buffer-id bid))
-              (setq-local eaf--browser-full-title title)
+              (setq-local eaf--full-title title)
               (rename-buffer (truncate-string-to-width title eaf-title-length))
               (throw 'find-buffer t))))))))
 

--- a/eaf.el
+++ b/eaf.el
@@ -312,14 +312,13 @@ keybinding variable to this list.")
 The bookmark will try to recreate eaf buffer session.
 For now only eaf browser app is supported."
   (cond ((equal eaf--buffer-app-name "browser")
-         (let ((bookmark `((handler . eaf--bookmark-restore)
-                           (eaf-app . "browser")
-                           (defaults . ,(list eaf--bookmark-title))
-                           ;; not a filename but this shows url in bookmark-list
-                           ;; which is nice
-                           (filename . ,(eaf-call "call_function"
-                                                  eaf--buffer-id "get_bookmark")))))
-           bookmark))))
+         `((handler . eaf--bookmark-restore)
+           (eaf-app . "browser")
+           (defaults . ,(list eaf--bookmark-title))
+           ;; not a filename but this shows url in bookmark-list
+           ;; which is nice
+           (filename . ,(eaf-call "call_function"
+                                  eaf--buffer-id "get_bookmark"))))))
 
 (defun eaf--bookmark-restore (bookmark)
   "Restore eaf buffer according to BOOKMARK."


### PR DESCRIPTION
This adds bookmark as discussed in #62 . For now only browser app is supported. I have shortly tested it and it work but needs more testing, I guess.

To test: `C- x r m` in browser app will add a bookmark. You can then open via `C-x r l` or whatever you use to open bookmarks (`helm-bookmarks`, `counsel-bookmark` or maybe snails ;)