### PR TITLE
Allow to provide regular emacs commands in app keybinding lists

### DIFF
--- a/eaf.el
+++ b/eaf.el
@@ -505,10 +505,12 @@ to edit EAF keybindings!" fun)))
             (define-key map (kbd single-key) 'eaf-send-key))
           (set-keymap-parent map eaf-mode-map*)
           (cl-loop for (key . fun) in keybinding
-                   do (let ((dummy (intern
-                                    (format "eaf-%s-%s" app-name fun))))
-                        (eaf-dummy-function dummy fun key)
-                        (define-key map (kbd key) dummy))
+                   do (if (symbolp fun)
+                          (define-key map (kbd key) fun)
+                        (let ((dummy (intern
+                                      (format "eaf-%s-%s" app-name fun))))
+                          (eaf-dummy-function dummy fun key)
+                          (define-key map (kbd key) dummy)))
                    finally return map))))
 
 (defun eaf-get-app-bindings (app-name)


### PR DESCRIPTION
If the key is mapped to a symbol it is an Emacs command otherwise
an app command. For example for pdf-viewer I wanted to bind q to bury-buffer command. 