### PR TITLE
Add remaining config vars

### DIFF
--- a/eaf.el
+++ b/eaf.el
@@ -325,24 +325,38 @@ argument and defaults to `switch-to-buffer'.")
 
 
 (defvar-local eaf--bookmark-title nil)
+(defvar eaf-app-bookmark-handlers-alist
+  '(("browser" . eaf--browser-bookmark)
+    ("pdf-viewer" . eaf--pdf-viewer-bookmark))
+  "Mapping app names to bookmark handler functions.
+
+A bookmark handler function is used as
+`bookmark-make-record-function' and should follow its spec.")
 
 (defun eaf--bookmark-make-record ()
   "Create a EAF bookmark.
 
 The bookmark will try to recreate EAF buffer session.
 For now only EAF browser app is supported."
-  (cond ((equal eaf--buffer-app-name "browser")
-         `((handler . eaf--bookmark-restore)
-           (eaf-app . "browser")
-           (defaults . ,(list eaf--bookmark-title))
-           (filename . ,(eaf-call "call_function"
-                                  eaf--buffer-id "get_bookmark"))))
-        ((equal eaf--buffer-app-name "pdf-viewer")
-         `((handler . eaf--bookmark-restore)
-           (eaf-app . "pdf-viewer")
-           (defaults . ,(list eaf--bookmark-title))
-           (filename . ,(eaf-call "call_function"
-                                  eaf--buffer-id "get_bookmark"))))))
+  (let ((handler (cdr
+                  (assoc eaf--buffer-app-name
+                         eaf-app-bookmark-handlers-alist))))
+    (when handler
+      (funcall handler))))
+
+(defun eaf--browser-bookmark ()
+  `((handler . eaf--bookmark-restore)
+    (eaf-app . "browser")
+    (defaults . ,(list eaf--bookmark-title))
+    (filename . ,(eaf-call "call_function"
+                           eaf--buffer-id "get_bookmark"))))
+
+(defun eaf--pdf-viewer-bookmark ()
+  `((handler . eaf--bookmark-restore)
+    (eaf-app . "pdf-viewer")
+    (defaults . ,(list eaf--bookmark-title))
+    (filename . ,(eaf-call "call_function"
+                           eaf--buffer-id "get_bookmark"))))
 
 (defun eaf--bookmark-restore (bookmark)
   "Restore EAF buffer according to BOOKMARK."

--- a/eaf.el
+++ b/eaf.el
@@ -1020,14 +1020,8 @@ Make sure that your smartphone is connected to the same WiFi network as this com
 Other files will open normally with `dired-find-file' or `dired-find-alternate-file'"
   (interactive)
   (dolist (file (dired-get-marked-files))
-    (cond ((member (file-name-extension file)
-                   (append eaf-pdf-extension-list
-                           eaf-markdown-extension-list
-                           eaf-image-extension-list
-                           eaf-video-extension-list
-                           eaf-browser-extension-list
-                           eaf-org-extension-list
-                           ))
+    (cond ((eaf--get-app-for-extension
+            (file-name-extension file))
            (eaf-open file))
           (eaf-find-alternate-file-in-dired
            (dired-find-alternate-file))


### PR DESCRIPTION
This adds config vars for bookmark and extensions. Next thing I want to work on is to have a single entry point to configure apps so one can do something like:

    (eaf-configure "browser"
                   :keys '(("C-q" . bury-buffer))
                   :display 'some-display-fun
                   :extensions '("xhtml")
                   :hook '(this-minor-mode and-that-minor-mode))

to add personal config to apps. And later adding a function `eaf-add-app` to automatically setup all variables when adding a new app.