### PR TITLE
pdf-viewer: jump link like Vimium

### DIFF
--- a/eaf.el
+++ b/eaf.el
@@ -235,7 +235,8 @@ Try not to modify this alist directly. Use `eaf-setq' to modify instead."
     ("p" . "jump_to_percent")
     ("[" . "remember_current_position")
     ("]" . "remember_jump")
-    ("i" . "toggle_inverted_mode"))
+    ("i" . "toggle_inverted_mode")
+    ("f" . "jump_to_link"))
   "The keybinding of EAF PDF Viewer."
   :type 'cons)
 

--- a/eaf.el
+++ b/eaf.el
@@ -236,6 +236,7 @@ Try not to modify this alist directly. Use `eaf-setq' to modify instead."
     ("[" . "remember_current_position")
     ("]" . "remember_jump")
     ("i" . "toggle_inverted_mode")
+    ("m" . "toggle_mark_link")
     ("f" . "jump_to_link"))
   "The keybinding of EAF PDF Viewer."
   :type 'cons)


### PR DESCRIPTION
Use send_input_message to listen to key events, so users must press RET to jump after entering the corresponding mark key.

Can EAF implement monitoring key input like hydra? '_'