### PR TITLE
Make EAF Browser history more flexible

### DIFF
--- a/app/browser/buffer.py
+++ b/app/browser/buffer.py
@@ -23,11 +23,14 @@ from PyQt5.QtCore import QUrl
 from PyQt5.QtGui import QColor
 from PyQt5.QtWebEngineWidgets import QWebEngineSettings
 from core.browser import BrowserBuffer
+from core.utils import touch
 import os
 
 class AppBuffer(BrowserBuffer):
     def __init__(self, buffer_id, url, config_dir, arguments):
         BrowserBuffer.__init__(self, buffer_id, url, config_dir, arguments, False, QColor(255, 255, 255, 255))
+
+        self.config_dir = config_dir
 
         # When arguments is "temp_html_file", browser will load content of html file, then delete temp file.
         # Usually use for render html mail.
@@ -39,9 +42,42 @@ class AppBuffer(BrowserBuffer):
         else:
             self.buffer_widget.setUrl(QUrl(url))
 
+        self.history_log_file_path = os.path.join(self.config_dir, "browser", "history", "log.txt")
+
+        self.buffer_widget.titleChanged.connect(self.record_history)
         self.buffer_widget.titleChanged.connect(self.change_title)
         self.buffer_widget.open_url_in_new_tab.connect(self.open_url)
         self.buffer_widget.translate_selected_text.connect(self.translate_text)
+
+    def clear_history(self):
+        if os.path.exists(self.history_log_file_path):
+            os.remove(self.history_log_file_path)
+            self.message_to_emacs.emit("Cleared browsing history.")
+        else:
+            self.message_to_emacs.emit("There is no browsing history.")
+
+    def record_history(self, title):
+        if self.emacs_var_dict["eaf-browser-remember-history"] == "true":
+            touch(self.history_log_file_path)
+            with open(self.history_log_file_path, "a") as f:
+                filtered_url = self.buffer_widget.filter_url(self.buffer_widget.url().toString())
+                if title == self.buffer_widget.url().toString():
+                    f.write(filtered_url + " " + filtered_url + "\n")
+                else:
+                    f.write(title + " " + filtered_url + "\n")
+
+            self.remove_duplicate_history()
+
+    def remove_duplicate_history(self):
+        lines_seen = set() # holds lines already seen
+        with open(self.history_log_file_path, "r") as f:
+            lines = f.readlines()
+
+        with open(self.history_log_file_path, "w") as f:
+            for line in lines:
+                if line not in lines_seen: # not a duplicate
+                    f.write(line)
+                    lines_seen.add(line)
 
     def update_settings(self):
         settings = QWebEngineSettings.globalSettings()

--- a/eaf.el
+++ b/eaf.el
@@ -7,7 +7,7 @@
 ;; Copyright (C) 2018, Andy Stewart, all rights reserved.
 ;; Created: 2018-06-15 14:10:12
 ;; Version: 0.5
-;; Last-Updated: Sat Jan 11 23:24:19 2020 (-0500)
+;; Last-Updated: Sat Jan 11 23:23:20 2020 (-0500)
 ;;           By: Mingde (Matthew) Zeng
 ;; URL: http://www.emacswiki.org/emacs/download/eaf.el
 ;; Keywords:
@@ -193,6 +193,7 @@ Otherwise they will be opened normally with `dired-find-file'.")
     (eaf-camera-save-path . "~/Downloads")
     (eaf-browser-enable-plugin . "true")
     (eaf-browser-enable-javascript . "true")
+    (eaf-browser-remember-history . "true")
     )
   "The alist storing user-defined variables that's shared with EAF Python side.
 
@@ -220,6 +221,7 @@ Try not to modify this alist directly.  Use `eaf-setq' to modify instead."
     ("M-f" . "history_forward")
     ("M-b" . "history_backward")
     ("M-q" . "clear_all_cookies")
+    ("C-M-q" . "clear_history")
     ("M-v" . "scroll_down_page")
     ("M-<" . "scroll_to_begin")
     ("M->" . "scroll_to_bottom")


### PR DESCRIPTION
- Add clear_history mapping to C-M-q to clear history
- Add eaf-browser-store-history variable for user to customize
- Move history functions to app/browser/buffer.py instead