### PR TITLE
pass elisp function to eaf backend and let it decide when to run it

### DIFF
--- a/core/browser.py
+++ b/core/browser.py
@@ -681,6 +681,12 @@ class BrowserBuffer(Buffer):
         else:
             self.goto_right_tab.emit()
 
+    def insert_or_elfun(self):
+        if self.is_focus():
+            self.fake_key_event(self.current_event_string)
+        else:
+            self.eval_in_emacs.emit(format("(funcall '{})".format(self.elfun)))
+
     def select_all_or_input_text(self):
         if self.is_focus():
             self.buffer_widget.select_input_text()

--- a/core/buffer.py
+++ b/core/buffer.py
@@ -179,6 +179,7 @@ class Buffer(QGraphicsScene):
         self.progressbar_height = 2
 
         self.current_event_string = ""
+        self.elfun = ""
 
     def drawForeground(self, painter, rect):
         if self.draw_progressbar:

--- a/eaf.el
+++ b/eaf.el
@@ -646,7 +646,12 @@ When called interactively, copy to ‘kill-ring’."
           (interactive)
           ;; Ensure this is only called from EAF buffer
           (if (derived-mode-p 'eaf-mode)
-              (eaf-call "execute_function" eaf--buffer-id fun (key-description (this-command-keys-vector)))
+              (let* ((or-elfun-regex ".+_or_elfun")
+                     (or-elfun-prefix (when (string-match or-elfun-regex fun)
+                                        (match-string 0 fun)))
+                     (pyfun (if or-elfun-prefix or-elfun-prefix fun))
+                     (elfun (if or-elfun-prefix (substring fun (1+ (length or-elfun-prefix))) "")))
+                (eaf-call "execute_function" eaf--buffer-id pyfun (key-description (this-command-keys-vector)) elfun))
             (user-error "%s command can only be called in an EAF buffer!" sym)))
         (format
          "Proxy function to call \"%s\" on the Python side.

--- a/eaf.py
+++ b/eaf.py
@@ -268,12 +268,13 @@ class EAF(dbus.service.Object):
             self.buffer_dict[buffer_id].handle_destroy()
             self.buffer_dict.pop(buffer_id, None)
 
-    @dbus.service.method(EAF_DBUS_NAME, in_signature="sss", out_signature="")
-    def execute_function(self, buffer_id, function_name, event_string):
+    @dbus.service.method(EAF_DBUS_NAME, in_signature="ssss", out_signature="")
+    def execute_function(self, buffer_id, function_name, event_string, elfun=""):
         if buffer_id in self.buffer_dict:
             try:
                 buffer = self.buffer_dict[buffer_id]
                 buffer.current_event_string = event_string
+                buffer.elfun = elfun
                 buffer.execute_function(function_name)
             except AttributeError:
                 import traceback


### PR DESCRIPTION
I think it's great to make "insert_or_COMMAND"s support elisp-funciton.

So I add a keybinding pattern(".+_or_elfun") to pass elisp function to eaf backend and let it decide when to run it.

key-send-function is just like "PyOrElfun_ElispFunctionName"
```
(eaf-bind-key pydowhatever_or_elfun_elisp-function "a" eaf-browser-keybinding)
```
browser.py
```
def pydowhatever_or_elfun(self):
    if (foo):
        # python do sth here
    else:
        self.eval_in_emacs.emit(format("(funcall '{})".format(self.elfun)))
```

For Exsample:

customize eaf browser keybinding
```  
(eaf-bind-key insert_or_elfun_eaf-open-bookmark "B" eaf-browser-keybinding)
```

browser.py
``` 
def insert_or_elfun(self):
    if self.is_focus():
        self.fake_key_event(self.current_event_string)
    else:
        self.eval_in_emacs.emit(format("(funcall '{})".format(self.elfun)))
```