### PR TITLE
Add Tips to Dependency list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,17 +78,17 @@ echo 'export LANG=zh_CN.UTF-8' >> ~/.bashrc
 ### Dependency List
 Packages listed as **Core** are mandatory to make EAF to work, whereas packages listed as **Application** are optional - install if you want the corresponding EAF feature.
 
-| Package       | Package Repo | Classification | Description and Depended by ...                         |
-| :--------     | :----        | :------        | :------                                                 |
-| pyqt5         | pip3         | Core           | Essential GUI library                                   |
-| dbus-python   | pip3         | Core           | DBus IPC to connect Python with Elisp                   |
-| python-xlib   | pip3         | Core           | Stick application window into Emacs frame               |
-| pyqtwebengine | pip3         | Core           | Depended by EAF Browser and some other EAF Applications |
-| pymupdf       | pip3         | Application    | Depended by EAF PDF Viewer                              |
-| grip          | pip3         | Application    | Depended by EAF Markdown Previewer                      |
-| qrcode        | pip3         | Application    | Depended by EAF File Transfer                           |
-| feedparser    | pip3         | Application    | Depended by EAF RSS Reader                              |
-| wetty         | yarn         | Application    | Depended by EAF Terminal                                |
+| Package       | Package Repo | Classification | Description and Depended by ...                         | Tips                                     |
+| :--------     | :----        | :------        | :------                                                 | :------                                  |
+| pyqt5         | pip3         | Core           | Essential GUI library                                   |                                          |
+| dbus-python   | pip3         | Core           | DBus IPC to connect Python with Elisp                   |                                          |
+| python-xlib   | pip3         | Core           | Stick application window into Emacs frame               |                                          |
+| pyqtwebengine | pip3         | Core           | Depended by EAF Browser and some other EAF Applications |                                          |
+| pymupdf       | pip3         | Application    | Depended by EAF PDF Viewer                              | pip3 install pymupdf==<suitable-version> |
+| grip          | pip3         | Application    | Depended by EAF Markdown Previewer                      |                                          |
+| qrcode        | pip3         | Application    | Depended by EAF File Transfer                           |                                          |
+| feedparser    | pip3         | Application    | Depended by EAF RSS Reader                              |                                          |
+| wetty         | yarn         | Application    | Depended by EAF Terminal                                |                                          |
 
 ## Launch EAF Applications
 | Application Name    | Launch                                                                 |


### PR DESCRIPTION
Debian 上安装 pymupdf 经常失败，因为 mupdf 版本低的原因，在
README中添加一个tip，省得pip不熟悉的同学遇到后抓狂

https://github.com/manateelazycat/emacs-application-framework/pull/188
https://emacs-china.org/t/debian10-eaf/11737/4