### PR TITLE
Use monolith to save web page as a single html

### DIFF
--- a/eaf.el
+++ b/eaf.el
@@ -314,6 +314,7 @@ Try not to modify this alist directly.  Use `eaf-setq' to modify instead."
     ("Y" . "insert_or_download_youtube_audio")
     ("p" . "insert_or_toggle_device")
     ("s" . "insert_or_save_as_pdf")
+    ("S" . "insert_or_save_as_single_file")
     ("v" . "insert_or_view_source")
     ("C-a" . "select_all_or_input_text")
     ("M-u" . "clear_focus")


### PR DESCRIPTION
It depends on `monolith`, an application that can save a webpage into a single html file, including css files, javascript files, and pictures, but it could only be installed manually in most Linux distributions. 
You can find `monolith` [here](https://github.com/Y2Z/monolith)