### PR TITLE
Fixed dev tool page "enter" keypress

### DIFF
--- a/core/buffer.py
+++ b/core/buffer.py
@@ -87,7 +87,8 @@ qt_key_dict.update({
     '''<prior>''': Qt.Key_PageUp,
     '''<next>''': Qt.Key_PageDown,
     '''<delete>''': Qt.Key_Delete,
-    '''<backspace>''': Qt.Key_Backspace
+    '''<backspace>''': Qt.Key_Backspace,
+    '''<return>''': Qt.Key_Return
 })
 
 qt_text_dict = {

--- a/eaf.el
+++ b/eaf.el
@@ -116,7 +116,7 @@
     (define-key map (kbd "M-[") #'eaf-share-path-or-url)
     (define-key map (vector 'remap #'keyboard-quit) #'eaf-keyboard-quit)
     (define-key map (vector 'remap #'self-insert-command) #'eaf-send-key)
-    (dolist (single-key '("RET" "DEL" "TAB" "SPC" "<backtab>" "<home>" "<end>" "<left>" "<right>" "<up>" "<down>" "<prior>" "<next>" "<delete>" "<backspace>"))
+    (dolist (single-key '("RET" "DEL" "TAB" "SPC" "<backtab>" "<home>" "<end>" "<left>" "<right>" "<up>" "<down>" "<prior>" "<next>" "<delete>" "<backspace>" "<return>"))
       (define-key map (kbd single-key) #'eaf-send-key))
     map)
   "Keymap for default bindings available in all apps.")


### PR DESCRIPTION
map `<return>` to Qt.Key_Return

跟之前的backspace按键一样，虽然发送了`RET`，但是不work，发现再添加一个`<return>`就好了，不知为何...