### PR TITLE
Eaf interleave

### DIFF
--- a/app/interleave/eaf-interleave.el
+++ b/app/interleave/eaf-interleave.el
@@ -151,20 +151,6 @@ split horizontally."
   "The pdf property string.")
 
 ;; functions
-(defun eaf-interleave--open-file ()
-  "Opens the pdf file in besides the notes buffer.
-
-SPLIT-WINDOW is a function that actually splits the window, so it must be either
-`split-window-right' or `split-window-below'."
-  (let ((pdf-file-name
-         (or (org-entry-get-with-inheritance eaf-interleave--url-prop)
-             (eaf-interleave--headline-pdf-path eaf-interleave-org-buffer)
-             (eaf-interleave--find-pdf-path eaf-interleave-org-buffer)
-             (eaf-interleave--handle-parse-pdf-file-name))))
-    (eaf-interleave--select-split-function)
-    (eaf-interleave--open-pdf pdf-file-name)
-    pdf-file-name))
-
 (defun eaf-interleave--handle-parse-pdf-file-name ()
   "When don't parse responsive pdf file on current org file."
   (let ((pdf-file-name (read-file-name "No INTERLEAVE_PDF property found. Please specify path: " nil nil t)))
@@ -176,25 +162,6 @@ SPLIT-WINDOW is a function that actually splits the window, so it must be either
         (goto-char (point-min))
         (insert "#+INTERLEAVE_PDF: " pdf-file-name)))
     pdf-file-name))
-
-(defun eaf-interleave--headline-pdf-path (buffer)
-  "Return the INTERLEAVE_PDF property of the current headline in BUFFER."
-  (with-current-buffer buffer
-    (save-excursion
-      (let ((headline (org-element-at-point)))
-        (when (and (equal (org-element-type headline) 'headline)
-                   (org-entry-get nil eaf-interleave--url-prop))
-          (org-entry-get nil eaf-interleave--url-prop))))))
-
-(defun eaf-interleave--find-pdf-path (buffer)
-  "Search the `interleave_pdf' property in BUFFER and extracts it when found."
-  (with-current-buffer buffer
-    (save-restriction
-      (widen)
-      (save-excursion
-        (goto-char (point-min))
-        (when (re-search-forward "^#\\+interleave_pdf: \\(.*\\)" nil :noerror)
-          (match-string 1))))))
 
 (defun eaf-interleave--select-split-function ()
   "Determine which split function to use.

--- a/app/interleave/eaf-interleave.el
+++ b/app/interleave/eaf-interleave.el
@@ -122,7 +122,7 @@ split horizontally."
         ;; expand/show all headlines if narrowing is disabled
         (when eaf-interleave-disable-narrowing
           (with-current-buffer eaf-interleave-org-buffer
-            (eaf-interleave--goto-search-position)
+            (goto-char (point-min))
             (org-cycle-hide-drawers 'all)))
         (eaf-interleave--go-to-page-note 1)
         (message "EAF Interleave enabled"))
@@ -221,13 +221,6 @@ based on a combination of `current-prefix-arg' and
         (enlarge-window-horizontally eaf-interleave-split-lines)))
     ))
 
-(defun eaf-interleave--goto-search-position ()
-  "Move point to the search start position.
-
-For multi-pdf notes this is the outermost parent headline.  For everything else
-this is the beginning of the buffer."
-  (goto-char (point-min)))
-
 (defun eaf-interleave--go-to-page-note (page)
   "Look up the notes for the current pdf PAGE.
 
@@ -242,7 +235,7 @@ It (possibly) narrows the subtree when found."
     (let (point (window (get-buffer-window (current-buffer) 'visible)))
       (save-excursion
         (widen)
-        (eaf-interleave--goto-search-position)
+        (goto-char (point-min))
         (when (re-search-forward (format "^\[ \t\r\]*\:interleave_page_note\: %d$" page) nil t)
           ;; widen the buffer again for the case it is narrowed from
           ;; multi-pdf notes search. Kinda ugly I know. Maybe a macro helps?
@@ -473,7 +466,7 @@ of .pdf)."
   (interactive)
   (with-current-buffer eaf-interleave-org-buffer
     (widen)
-    (eaf-interleave--goto-search-position)
+    (goto-char (point-min))
     (when (eaf-interleave--headlines-available-p)
       (org-overview))
     (eaf-interleave-mode 0)))

--- a/app/interleave/eaf-interleave.el
+++ b/app/interleave/eaf-interleave.el
@@ -204,8 +204,7 @@ It (possibly) narrows the subtree when found."
   "Add new url on note if property is none. else modify current url"
   (interactive)
   (let ((url (read-file-name "Please specify path: " nil nil t)))
-    (org-entry-put (point) eaf-interleave--url-prop url)
-    (org-entry-put (point) eaf-interleave--page-note-prop "1")))
+    (org-entry-put (point) eaf-interleave--url-prop url)))
 
 
 (defun eaf-interleave--narrow-to-subtree (&optional force)
@@ -289,15 +288,16 @@ Return the position of the newly inserted heading."
 (defun eaf-interleave-sync-pdf-page-current ()
   "Open PDF page for currently visible notes."
   (interactive)
-  (let* ((pdf-page (string-to-number (org-entry-get-with-inheritance eaf-interleave--page-note-prop)))
+  (let* ((pdf-page (org-entry-get-with-inheritance eaf-interleave--page-note-prop))
          (pdf-url (org-entry-get-with-inheritance eaf-interleave--url-prop))
          (buffer (eaf-interleave--find-buffer pdf-url)))
     (if buffer
-        (when (and (integerp pdf-page) (> pdf-page 0)) ; The page number needs to be a positive integer
+        (progn
           (eaf-interleave--narrow-to-subtree)
           (display-buffer-reuse-mode-window buffer '(("mode" . "eaf-interleave-pdf-mode")))
-          (with-current-buffer buffer
-            (eaf-interleave--pdf-viewer-goto-page pdf-url pdf-page)))
+          (when pdf-page
+            (with-current-buffer buffer
+            (eaf-interleave--pdf-viewer-goto-page pdf-url pdf-page))))
       (eaf-interleave--select-split-function)
       (eaf-interleave--open-pdf pdf-url)
       )))

--- a/app/interleave/eaf-interleave.el
+++ b/app/interleave/eaf-interleave.el
@@ -64,13 +64,6 @@ as \"/pdf/file/dir/\", \"./notes\" is interpreted as
 \"/pdf/file/dir/notes/\"."
   :type '(repeat directory))
 
-(defcustom eaf-interleave-sort-order 'asc
-  "Specifiy the notes' sort order in the notes buffer.
-
-The possible values are 'asc for ascending and 'desc for descending."
-  :type '(choice (const  asc)
-                 (const  desc)))
-
 (defcustom eaf-interleave-split-direction 'vertical
   "Specify how to split the notes buffer."
   :type '(choice (const vertical)
@@ -482,7 +475,6 @@ of .pdf)."
     (widen)
     (eaf-interleave--goto-search-position)
     (when (eaf-interleave--headlines-available-p)
-      (eaf-interleave--sort-notes eaf-interleave-sort-order)
       (org-overview))
     (eaf-interleave-mode 0)))
 
@@ -490,20 +482,6 @@ of .pdf)."
   "True if there are headings in the notes buffer."
   (save-excursion
     (re-search-forward "^\* .*" nil t)))
-
-(defun eaf-interleave--sort-notes (sort-order)
-  "Sort notes by interleave_page_property.
-
-SORT-ORDER is either 'asc or 'desc."
-  (condition-case nil
-      (org-sort-entries nil ?f
-                        (lambda ()
-                          (let ((page-note (org-entry-get nil "interleave_page_note")))
-                            (if page-note (string-to-number page-note) -1)))
-                        (if (eq sort-order 'asc)
-                            #'<
-                          #'>))
-    ('user-error nil)))
 
 ;; utils
 (defun eaf-interleave--eaf-open-pdf (pdf-file-name)

--- a/app/interleave/eaf-interleave.el
+++ b/app/interleave/eaf-interleave.el
@@ -273,13 +273,7 @@ This shows the next notes and synchronizes the PDF to the right page number."
   (interactive)
   (eaf-interleave--switch-to-org-buffer)
   (widen)
-  ;; go to the first notes heading if we're not at an headline or if
-  ;; we're on multi-pdf heading. This is useful to quickly jump to the
-  ;; notes if they start at page 96 or so. Image you need to skip page
-  ;; for page.
-  (if (eaf-interleave--goto-parent-headline eaf-interleave--page-note-prop)
-      (org-forward-heading-same-level 1)
-    (outline-next-visible-heading 1))
+  (org-forward-heading-same-level 1)
   (eaf-interleave--narrow-to-subtree)
   (org-show-subtree)
   (org-cycle-hide-drawers t)

--- a/app/interleave/eaf-interleave.el
+++ b/app/interleave/eaf-interleave.el
@@ -283,7 +283,7 @@ It (possibly) narrows the subtree when found."
   (let ((id (buffer-local-value 'eaf--buffer-id (eaf-interleave--find-buffer url))))
     (eaf-call "handle_input_message" id "jump_page" page)))
 
-(defun eaf-interleave-sync-pdf-page-previous ()
+(defun eaf-interleave-sync-previous-note ()
   "Move to the previous set of notes.
 This show the previous notes and synchronizes the PDF to the right page number."
   (interactive)
@@ -294,9 +294,9 @@ This show the previous notes and synchronizes the PDF to the right page number."
   (eaf-interleave--narrow-to-subtree)
   (org-show-subtree)
   (org-cycle-hide-drawers t)
-  (eaf-interleave-sync-pdf-page-current))
+  (eaf-interleave-sync-current-note))
 
-(defun eaf-interleave-sync-pdf-page-next ()
+(defun eaf-interleave-sync-next-note ()
   "Move to the next set of notes.
 This shows the next notes and synchronizes the PDF to the right page number."
   (interactive)
@@ -312,7 +312,7 @@ This shows the next notes and synchronizes the PDF to the right page number."
   (eaf-interleave--narrow-to-subtree)
   (org-show-subtree)
   (org-cycle-hide-drawers t)
-  (eaf-interleave-sync-pdf-page-current))
+  (eaf-interleave-sync-current-note))
 
 (defun eaf-interleave--goto-parent-headline (property)
   "Traverse the tree until the parent headline.
@@ -415,6 +415,13 @@ buffer."
     (if position
         (eaf-interleave--switch-to-org-buffer t position)
       (eaf-interleave--create-new-note eaf--buffer-url page)))
+  )
+
+(defun eaf-interleave-sync-current-note ()
+  "Sync EAF buffer on current note"
+  (let ((url (org-entry-get-with-inheritance eaf-interleave--url-prop)))
+    (cond ((and (string-prefix-p "/" url) (string-suffix-p "pdf" url t))
+           (eaf-interleave-sync-pdf-page-current))))
   )
 
 (defun eaf-interleave-sync-pdf-page-current ()

--- a/app/interleave/eaf-interleave.el
+++ b/app/interleave/eaf-interleave.el
@@ -348,11 +348,14 @@ This shows the next notes and synchronizes the PDF to the right page number."
 If there are already notes for this url, jump to the notes
 buffer."
   (interactive)
-  (cond ((and (derived-mode-p 'eaf-mode)
-              (equal eaf--buffer-app-name "pdf-viewer"))
-         (eaf-interleave-pdf-add-note))))
+  (if (derived-mode-p 'eaf-mode)
+      (cond ((equal eaf--buffer-app-name "pdf-viewer")
+             (eaf-interleave--pdf-add-note))
+            ((equal eaf--buffer-app-name "browser")
+             (eaf-interleave--browser-add-note)))
+    ))
 
-(defun eaf-interleave-pdf-add-note ()
+(defun eaf-interleave--pdf-add-note ()
   "EAF pdf-viewer-mode add note"
   (let* ((page (eaf-interleave--pdf-viewer-current-page eaf--buffer-url))
          (position (eaf-interleave--go-to-page-note page)))

--- a/app/interleave/eaf-interleave.el
+++ b/app/interleave/eaf-interleave.el
@@ -170,7 +170,7 @@ SPLIT-WINDOW is a function that actually splits the window, so it must be either
              (eaf-interleave--find-pdf-path eaf-interleave-org-buffer)
              (eaf-interleave--handle-parse-pdf-file-name))))
     (eaf-interleave--select-split-function)
-    (eaf-interleave--eaf-open-pdf pdf-file-name)
+    (eaf-interleave--open-pdf pdf-file-name)
     pdf-file-name))
 
 (defun eaf-interleave--handle-parse-pdf-file-name ()
@@ -477,7 +477,7 @@ of .pdf)."
     (re-search-forward "^\* .*" nil t)))
 
 ;; utils
-(defun eaf-interleave--eaf-open-pdf (pdf-file-name)
+(defun eaf-interleave--open-pdf (pdf-file-name)
   "Use EAF PdfViewer open this pdf-file-name document."
   (eaf-open pdf-file-name)
   (add-hook 'eaf-pdf-viewer-hook 'eaf-interleave-pdf-mode))

--- a/app/interleave/eaf-interleave.el
+++ b/app/interleave/eaf-interleave.el
@@ -151,17 +151,11 @@ split horizontally."
   "The pdf property string.")
 
 ;; functions
-(defun eaf-interleave--handle-parse-pdf-file-name ()
-  "When don't parse responsive pdf file on current org file."
-  (let ((pdf-file-name (read-file-name "No INTERLEAVE_PDF property found. Please specify path: " nil nil t)))
-    ;; Check whether we have any entry at point with `org-entry-properties' before
-    ;; prompting if the user wants multi-pdf.
-    (if (and (org-entry-properties) (y-or-n-p "Is this multi-pdf? "))
-        (org-entry-put (point) "INTERLEAVE_PDF" pdf-file-name)
-      (save-excursion
-        (goto-char (point-min))
-        (insert "#+INTERLEAVE_PDF: " pdf-file-name)))
-    pdf-file-name))
+(defun eaf-interleave-add-file-url ()
+  "Add new url on note if property is none. else modify current url"
+  (interactive)
+  (let ((url (read-file-name "Please specify path: " nil nil t)))
+    (org-entry-put (point) eaf-interleave--url-prop url)))
 
 (defun eaf-interleave--select-split-function ()
   "Determine which split function to use.

--- a/app/interleave/eaf-interleave.el
+++ b/app/interleave/eaf-interleave.el
@@ -162,7 +162,7 @@ split horizontally."
 (defconst eaf-interleave--page-note-prop "interleave_page_note"
   "The page note property string.")
 
-(defconst eaf-interleave--pdf-prop "interleave_pdf"
+(defconst eaf-interleave--url-prop "interleave_url"
   "The pdf property string.")
 
 ;; functions
@@ -202,8 +202,8 @@ SPLIT-WINDOW is a function that actually splits the window, so it must be either
     (save-excursion
       (let ((headline (org-element-at-point)))
         (when (and (equal (org-element-type headline) 'headline)
-                   (org-entry-get nil eaf-interleave--pdf-prop))
-          (org-entry-get nil eaf-interleave--pdf-prop))))))
+                   (org-entry-get nil eaf-interleave--url-prop))
+          (org-entry-get nil eaf-interleave--url-prop))))))
 
 (defun eaf-interleave--find-pdf-path (buffer)
   "Search the `interleave_pdf' property in BUFFER and extracts it when found."
@@ -398,7 +398,7 @@ Return the position of the newly inserted heading."
         (let ((position (eaf-interleave--goto-insert-position)))
           (setq new-note-position (eaf-interleave--insert-heading-respect-content position)))
         (insert (format "Notes for page %d" page))
-        (org-set-property eaf-interleave--pdf-prop url)
+        (org-set-property eaf-interleave--url-prop url)
         (org-set-property eaf-interleave--page-note-prop (number-to-string page))
         (eaf-interleave--narrow-to-subtree)
         (org-cycle-hide-drawers t)))
@@ -427,7 +427,7 @@ buffer."
   "Open PDF page for currently visible notes."
   (interactive)
   (let ((pdf-page (string-to-number (org-entry-get-with-inheritance eaf-interleave--page-note-prop)))
-        (pdf-url (org-entry-get-with-inheritance eaf-interleave--pdf-prop)))
+        (pdf-url (org-entry-get-with-inheritance eaf-interleave--url-prop)))
     (when (and (integerp pdf-page) (> pdf-page 0)) ; The page number needs to be a positive integer
       (eaf-interleave--narrow-to-subtree)
       (with-current-buffer (eaf-interleave--find-buffer pdf-url)

--- a/app/interleave/eaf-interleave.el
+++ b/app/interleave/eaf-interleave.el
@@ -549,5 +549,11 @@ SORT-ORDER is either 'asc or 'desc."
             (throw 'find-buffer t)))))
     current-buffer))
 
+(defun eaf-interleave--kill-buffer (url)
+  "Kill the current converter process and buffer."
+  (interactive)
+  (let ((buffer (eaf-interleave--find-buffer url)))
+    (kill-buffer buffer)))
+
 (provide 'eaf-interleave)
 ;;; interleave.el ends here

--- a/app/interleave/eaf-interleave.el
+++ b/app/interleave/eaf-interleave.el
@@ -424,7 +424,7 @@ Return the position of the newly inserted heading."
       (funcall change-level)))
   (point))
 
-(defun eaf-interleave--create-new-note (page)
+(defun eaf-interleave--create-new-note (url page)
   "Create a new headline for the page PAGE."
   (let (new-note-position)
     (with-current-buffer eaf-interleave-org-buffer
@@ -433,6 +433,7 @@ Return the position of the newly inserted heading."
         (let ((position (eaf-interleave--goto-insert-position)))
           (setq new-note-position (eaf-interleave--insert-heading-respect-content position)))
         (insert (format "Notes for page %d" page))
+        (org-set-property eaf-interleave--pdf-prop url)
         (org-set-property eaf-interleave--page-note-prop (number-to-string page))
         (eaf-interleave--narrow-to-subtree)
         (org-cycle-hide-drawers t)))
@@ -448,7 +449,8 @@ buffer."
          (position (eaf-interleave--go-to-page-note page)))
     (if position
         (eaf-interleave--switch-to-org-buffer t position)
-      (eaf-interleave--create-new-note page))))
+      (eaf-interleave--create-new-note eaf--buffer-url page)))
+  )
 
 (defun eaf-interleave-sync-pdf-page-current ()
   "Open PDF page for currently visible notes."

--- a/app/interleave/eaf-interleave.el
+++ b/app/interleave/eaf-interleave.el
@@ -295,9 +295,10 @@ Return the position of the newly inserted heading."
         (progn
           (eaf-interleave--narrow-to-subtree)
           (display-buffer-reuse-mode-window buffer '(("mode" . "eaf-interleave-pdf-mode")))
+          (eaf-interleave--ensure-buffer-window buffer)
           (when pdf-page
             (with-current-buffer buffer
-            (eaf-interleave--pdf-viewer-goto-page pdf-url pdf-page))))
+              (eaf-interleave--pdf-viewer-goto-page pdf-url pdf-page))))
       (eaf-interleave--select-split-function)
       (eaf-interleave--open-pdf pdf-url)
       )))
@@ -460,6 +461,13 @@ of .pdf)."
   "goto page"
   (let ((id (buffer-local-value 'eaf--buffer-id (eaf-interleave--find-buffer url))))
     (eaf-call "handle_input_message" id "jump_page" page)))
+
+(defun eaf-interleave--ensure-buffer-window (buffer)
+  "If BUFFER don't display, will use other window display"
+  (if (get-buffer-window buffer)
+      nil
+    (eaf-interleave--select-split-function)
+    (switch-to-buffer buffer)))
 
 (provide 'eaf-interleave)
 ;;; interleave.el ends here

--- a/app/interleave/eaf-interleave.el
+++ b/app/interleave/eaf-interleave.el
@@ -204,7 +204,8 @@ It (possibly) narrows the subtree when found."
   "Add new url on note if property is none. else modify current url"
   (interactive)
   (let ((url (read-file-name "Please specify path: " nil nil t)))
-    (org-entry-put (point) eaf-interleave--url-prop url)))
+    (org-entry-put (point) eaf-interleave--url-prop url)
+    (org-entry-put (point) eaf-interleave--page-note-prop "1")))
 
 
 (defun eaf-interleave--narrow-to-subtree (&optional force)

--- a/app/interleave/eaf-interleave.el
+++ b/app/interleave/eaf-interleave.el
@@ -226,6 +226,16 @@ This show the previous notes and synchronizes the PDF to the right page number."
              (eaf-interleave--open-notes-file-for-browser))))
   )
 
+(defun eaf-interleave-quit ()
+  "Quit interleave mode."
+  (interactive)
+  (with-current-buffer eaf-interleave-org-buffer
+    (widen)
+    (goto-char (point-min))
+    (when (eaf-interleave--headlines-available-p)
+      (org-overview))
+    (eaf-interleave-mode 0)))
+
 ;;;###autoload
 (defun eaf-interleave--open-notes-file-for-pdf ()
   "Open the notes org file for the current pdf file if it exists.
@@ -260,17 +270,6 @@ Else create it."
     (switch-to-buffer buffer)
     ))
 
-(defun eaf-interleave-quit ()
-  "Quit interleave mode."
-  (interactive)
-  (with-current-buffer eaf-interleave-org-buffer
-    (widen)
-    (goto-char (point-min))
-    (when (eaf-interleave--headlines-available-p)
-      (org-overview))
-    (eaf-interleave-mode 0)))
-
-;;
 (defun eaf-interleave--select-split-function ()
   "Determine which split function to use.
 

--- a/app/interleave/eaf-interleave.el
+++ b/app/interleave/eaf-interleave.el
@@ -141,10 +141,9 @@ split horizontally."
     (setq eaf-interleave--window-configuration nil)
     (setq eaf-interleave-org-buffer nil)
     (setq eaf-interleave--current-pdf-file nil)
-    (with-current-buffer eaf-interleave-pdf-buffer
+    (with-current-buffer (eaf-interleave--find-buffer eaf-interleave--current-pdf-file)
       (eaf-interleave-pdf-mode -1)
       (eaf-interleave-pdf-kill-buffer))
-    (setq eaf-interleave-pdf-buffer nil)
     ))
 
 ;;; Interleave PDF Mode
@@ -160,15 +159,11 @@ split horizontally."
   (when eaf-interleave-pdf-mode
     ;; if derived mode is eaf.
     (unless eaf-interleave--current-pdf-file
-      (setq eaf-interleave--current-pdf-file eaf--buffer-url))
-    (setq eaf-interleave-pdf-buffer (get-buffer (file-name-nondirectory eaf-interleave--current-pdf-file)))))
+      (setq eaf-interleave--current-pdf-file eaf--buffer-url))))
 
 ;; variables
 (defvar eaf-interleave-org-buffer nil
   "Org notes buffer name.")
-
-(defvar eaf-interleave-pdf-buffer nil
-  "Name of PDF buffer associated with `eaf-interleave-org-buffer'.")
 
 (defvar eaf-interleave--window-configuration nil
   "Variable to store the window configuration before interleave mode was enabled.")
@@ -301,17 +296,17 @@ It (possibly) narrows the subtree when found."
 (defun eaf-interleave-pdf-kill-buffer ()
   "Kill the current converter process and buffer."
   (interactive)
-  (when eaf-interleave-pdf-buffer
-    (kill-buffer eaf-interleave-pdf-buffer)))
+  (when (eaf-interleave--find-buffer eaf-interleave--current-pdf-file)
+    (kill-buffer (eaf-interleave--find-buffer eaf-interleave--current-pdf-file))))
 
 (defun eaf-interleave--pdf-viewer-current-page ()
   "get current page index."
-  (let ((id (buffer-local-value 'eaf--buffer-id eaf-interleave-pdf-buffer)))
+  (let ((id (buffer-local-value 'eaf--buffer-id (eaf-interleave--find-buffer eaf-interleave--current-pdf-file))))
     (string-to-number (eaf-call "call_function" id "current_page"))))
 
 (defun eaf-interleave--pdf-viewer-goto-page (page)
   "goto page"
-  (let ((id (buffer-local-value 'eaf--buffer-id eaf-interleave-pdf-buffer)))
+  (let ((id (buffer-local-value 'eaf--buffer-id (eaf-interleave--find-buffer eaf-interleave--current-pdf-file))))
     (eaf-call "handle_input_message" id "jump_page" page)))
 
 (defun eaf-interleave-sync-pdf-page-previous ()
@@ -461,7 +456,7 @@ buffer."
   (let ((pdf-page (string-to-number (org-entry-get-with-inheritance eaf-interleave--page-note-prop))))
     (when (and (integerp pdf-page) (> pdf-page 0)) ; The page number needs to be a positive integer
       (eaf-interleave--narrow-to-subtree)
-      (with-current-buffer eaf-interleave-pdf-buffer
+      (with-current-buffer (eaf-interleave--find-buffer eaf-interleave--current-pdf-file)
         (eaf-interleave--pdf-viewer-goto-page pdf-page))
       )))
 

--- a/app/interleave/eaf-interleave.el
+++ b/app/interleave/eaf-interleave.el
@@ -355,7 +355,7 @@ If POSITION is non-nil move point to it."
     (save-restriction
       (when eaf-interleave-disable-narrowing
         (eaf-interleave--narrow-to-subtree t))
-      (eaf-interleave--goto-insert-position))
+      (goto-char (point-max)))
     ;; Expand again. Sometimes the new content is outside the narrowed
     ;; region.
     (org-show-subtree)
@@ -363,13 +363,6 @@ If POSITION is non-nil move point to it."
     ;; Insert a new line if not already on a new line
     (when (not (looking-back "^ *" (line-beginning-position)))
       (org-return))))
-
-(defun eaf-interleave--goto-insert-position ()
-  "Move the point to the right insert postion.
-
-For multi-pdf notes this is the end of the subtree.  For everything else
-this is the end of the buffer"
-  (goto-char (point-max)))
 
 (defun eaf-interleave--insert-heading-respect-content (parent-headline)
   "Create a new heading in the notes buffer.
@@ -395,7 +388,7 @@ Return the position of the newly inserted heading."
     (with-current-buffer eaf-interleave-org-buffer
       (save-excursion
         (widen)
-        (let ((position (eaf-interleave--goto-insert-position)))
+        (let ((position (goto-char (point-max))))
           (setq new-note-position (eaf-interleave--insert-heading-respect-content position)))
         (insert (format "Notes for page %d" page))
         (org-set-property eaf-interleave--url-prop url)

--- a/app/interleave/eaf-interleave.el
+++ b/app/interleave/eaf-interleave.el
@@ -192,11 +192,6 @@ SPLIT-WINDOW is a function that actually splits the window, so it must be either
         (insert "#+INTERLEAVE_PDF: " pdf-file-name)))
     pdf-file-name))
 
-(defun eaf-interleave--eaf-open-pdf (pdf-file-name)
-  "Use EAF PdfViewer open this pdf-file-name document."
-  (eaf-open pdf-file-name)
-  (add-hook 'eaf-pdf-viewer-hook 'eaf-interleave-pdf-mode))
-
 (defun eaf-interleave--headline-pdf-path (buffer)
   "Return the INTERLEAVE_PDF property of the current headline in BUFFER."
   (with-current-buffer buffer
@@ -272,16 +267,6 @@ It (possibly) narrows the subtree when found."
           (goto-char point)
           (recenter)))
       point)))
-
-(defun eaf-interleave--pdf-viewer-current-page (url)
-  "get current page index."
-  (let ((id (buffer-local-value 'eaf--buffer-id (eaf-interleave--find-buffer url))))
-    (string-to-number (eaf-call "call_function" id "current_page"))))
-
-(defun eaf-interleave--pdf-viewer-goto-page (url page)
-  "goto page"
-  (let ((id (buffer-local-value 'eaf--buffer-id (eaf-interleave--find-buffer url))))
-    (eaf-call "handle_input_message" id "jump_page" page)))
 
 (defun eaf-interleave-sync-previous-note ()
   "Move to the previous set of notes.
@@ -521,6 +506,11 @@ SORT-ORDER is either 'asc or 'desc."
     ('user-error nil)))
 
 ;; utils
+(defun eaf-interleave--eaf-open-pdf (pdf-file-name)
+  "Use EAF PdfViewer open this pdf-file-name document."
+  (eaf-open pdf-file-name)
+  (add-hook 'eaf-pdf-viewer-hook 'eaf-interleave-pdf-mode))
+
 (defun eaf-interleave--find-buffer (url)
   "find EAF buffer base url"
   (let (current-buffer)
@@ -539,6 +529,16 @@ SORT-ORDER is either 'asc or 'desc."
   (interactive)
   (let ((buffer (eaf-interleave--find-buffer url)))
     (kill-buffer buffer)))
+
+(defun eaf-interleave--pdf-viewer-current-page (url)
+  "get current page index."
+  (let ((id (buffer-local-value 'eaf--buffer-id (eaf-interleave--find-buffer url))))
+    (string-to-number (eaf-call "call_function" id "current_page"))))
+
+(defun eaf-interleave--pdf-viewer-goto-page (url page)
+  "goto page"
+  (let ((id (buffer-local-value 'eaf--buffer-id (eaf-interleave--find-buffer url))))
+    (eaf-call "handle_input_message" id "jump_page" page)))
 
 (provide 'eaf-interleave)
 ;;; interleave.el ends here

--- a/app/interleave/eaf-interleave.el
+++ b/app/interleave/eaf-interleave.el
@@ -137,8 +137,7 @@ split horizontally."
     ))
 
 (defvar eaf-interleave-app-mode-map (make-sparse-keymap)
-  "Keymap while command `eaf-interleave-app-mode' is active."
-  )
+  "Keymap while command `eaf-interleave-app-mode' is active.")
 
 ;;;###autoload
 (define-minor-mode eaf-interleave-app-mode
@@ -230,13 +229,25 @@ This show the previous notes and synchronizes the PDF to the right page number."
 ;;;###autoload
 (defun eaf-interleave--open-notes-file-for-pdf ()
   "Open the notes org file for the current pdf file if it exists.
-Else create it.
+Else create it. It is assumed that the notes org file will have
+the exact same base name as the pdf file (just that the notes
+file will have a .org extension instead of .pdf)."
+  (let ((org-file (concat (file-name-base eaf--buffer-url) ".org")))
+    (eaf-interleave--open-notes-file-for-app org-file)))
 
-It is assumed that the notes org file will have the exact same base name
-as the pdf file (just that the notes file will have a .org extension instead
-of .pdf)."
-  (let ((org-file (concat (file-name-base eaf--buffer-url) ".org"))
-        (default-dir (nth 0 eaf-interleave-org-notes-dir-list))
+(defun eaf-interleave--open-notes-file-for-browser ()
+  "Find current open interleave-mode org file, if exists, else
+will create new org file with URL. It is assumed that the notes
+org file will have the exact sam base name as the url domain."
+  (unless (buffer-live-p eaf-interleave-org-buffer)
+    (let* ((domain (url-domain (url-generic-parse-url eaf--buffer-url)))
+           (org-file (concat domain ".org")))
+      (eaf-interleave--open-notes-file-for-app org-file))))
+
+(defun eaf-interleave--open-notes-file-for-app (org-file)
+  "Open the notes org file for the current url if it exists.
+Else create it."
+  (let ((default-dir (nth 0 eaf-interleave-org-notes-dir-list))
         (org-file-path (eaf-interleave--find-match-org eaf-interleave-org-notes-dir-list eaf--buffer-url))
         (buffer (eaf-interleave--find-buffer eaf--buffer-url)))
     ;; Create the notes org file if it does not exist
@@ -248,12 +259,6 @@ of .pdf)."
     (eaf-interleave--select-split-function)
     (switch-to-buffer buffer)
     ))
-
-(defun eaf-interleave--open-notes-file-for-browser ()
-  "Find current open interleave-mode org file, if exists, else will create new org file with URL."
-  (if eaf-interleave-org-buffer
-      nil
-    nil))
 
 (defun eaf-interleave-quit ()
   "Quit interleave mode."

--- a/app/interleave/eaf-interleave.el
+++ b/app/interleave/eaf-interleave.el
@@ -440,11 +440,17 @@ Return the position of the newly inserted heading."
     (eaf-interleave--switch-to-org-buffer t new-note-position)))
 
 (defun eaf-interleave-add-note ()
-  "Add note for the current page.
+  "Add note for the EAF buffer.
 
-If there are already notes for this page, jump to the notes
+If there are already notes for this url, jump to the notes
 buffer."
   (interactive)
+  (cond ((and (derived-mode-p 'eaf-mode)
+              (equal eaf--buffer-app-name "pdf-viewer"))
+         (eaf-interleave-pdf-add-note))))
+
+(defun eaf-interleave-pdf-add-note ()
+  "EAF pdf-viewer-mode add note"
   (let* ((page (eaf-interleave--pdf-viewer-current-page))
          (position (eaf-interleave--go-to-page-note page)))
     (if position

--- a/app/interleave/eaf-interleave.el
+++ b/app/interleave/eaf-interleave.el
@@ -136,17 +136,14 @@ split horizontally."
     (setq eaf-interleave-org-buffer nil)
     ))
 
-;;; Interleave PDF Mode
-;; Minor mode for the pdf file buffer associated with the notes
-(defvar eaf-interleave-pdf-mode-map (make-sparse-keymap)
-  "Keymap while command `eaf-interleave-pdf-mode' is active in the pdf file buffer."
+(defvar eaf-interleave-app-mode-map (make-sparse-keymap)
+  "Keymap while command `eaf-interleave-app-mode' is active."
   )
 
 ;;;###autoload
-(define-minor-mode eaf-interleave-pdf-mode
-  "Interleave view for the pdf."
-  :keymap eaf-interleave-pdf-mode-map)
-
+(define-minor-mode eaf-interleave-app-mode
+  "Interleave view for the EAF app."
+  :keymap eaf-interleave-app-mode-map)
 
 ;;; functions
 ;; interleave mode
@@ -262,17 +259,19 @@ Return the position of the newly inserted heading."
       (funcall change-level)))
   (point))
 
-(defun eaf-interleave--create-new-note (url page)
-  "Create a new headline for the page PAGE."
+(defun eaf-interleave--create-new-note (url &optional title page)
+  "Create a new headline for current EAF url."
   (let (new-note-position)
     (with-current-buffer eaf-interleave-org-buffer
       (save-excursion
         (widen)
         (let ((position (goto-char (point-max))))
           (setq new-note-position (eaf-interleave--insert-heading-respect-content position)))
-        (insert (format "Notes for page %d" page))
         (org-set-property eaf-interleave--url-prop url)
-        (org-set-property eaf-interleave--page-note-prop (number-to-string page))
+        (when title
+          (insert (format "Notes for %s" title)))
+        (when page
+          (org-set-property eaf-interleave--page-note-prop (number-to-string page)))
         (eaf-interleave--narrow-to-subtree)
         (org-cycle-hide-drawers t)))
     (eaf-interleave--switch-to-org-buffer t new-note-position)))
@@ -361,8 +360,12 @@ buffer."
          (position (eaf-interleave--go-to-page-note page)))
     (if position
         (eaf-interleave--switch-to-org-buffer t position)
-      (eaf-interleave--create-new-note eaf--buffer-url page)))
+      (eaf-interleave--create-new-note eaf--buffer-url eaf--buffer-app-name page)))
   )
+
+(defun eaf-interleave--browser-add-note ()
+  "EAF browser add note"
+  (eaf-interleave--create-new-note eaf--buffer-url eaf--buffer-app-name))
 
 ;;;###autoload
 (defun eaf-interleave-open-notes-file-for-pdf ()

--- a/app/interleave/eaf-interleave.el
+++ b/app/interleave/eaf-interleave.el
@@ -547,5 +547,19 @@ SORT-ORDER is either 'asc or 'desc."
                           #'>))
     ('user-error nil)))
 
+;; utils
+(defun eaf-interleave--find-buffer (url)
+  "find EAF buffer base url"
+  (let (current-buffer)
+    (catch 'find-buffer
+    (dolist (buffer (buffer-list))
+      (with-current-buffer buffer
+          (when (and
+                 (derived-mode-p 'eaf-mode)
+                 (equal eaf--buffer-url url))
+            (setq current-buffer buffer)
+            (throw 'find-buffer t)))))
+    current-buffer))
+
 (provide 'eaf-interleave)
 ;;; interleave.el ends here

--- a/app/interleave/eaf-interleave.el
+++ b/app/interleave/eaf-interleave.el
@@ -172,9 +172,10 @@ split horizontally."
 SPLIT-WINDOW is a function that actually splits the window, so it must be either
 `split-window-right' or `split-window-below'."
   (let ((pdf-file-name
-          (or (eaf-interleave--headline-pdf-path eaf-interleave-org-buffer)
-              (eaf-interleave--find-pdf-path eaf-interleave-org-buffer)
-              (eaf-interleave--handle-parse-pdf-file-name))))
+         (or (org-entry-get-with-inheritance eaf-interleave--url-prop)
+             (eaf-interleave--headline-pdf-path eaf-interleave-org-buffer)
+             (eaf-interleave--find-pdf-path eaf-interleave-org-buffer)
+             (eaf-interleave--handle-parse-pdf-file-name))))
     (eaf-interleave--select-split-function)
     (eaf-interleave--eaf-open-pdf pdf-file-name)
     pdf-file-name))
@@ -419,12 +420,16 @@ buffer."
 (defun eaf-interleave-sync-pdf-page-current ()
   "Open PDF page for currently visible notes."
   (interactive)
-  (let ((pdf-page (string-to-number (org-entry-get-with-inheritance eaf-interleave--page-note-prop)))
-        (pdf-url (org-entry-get-with-inheritance eaf-interleave--url-prop)))
-    (when (and (integerp pdf-page) (> pdf-page 0)) ; The page number needs to be a positive integer
-      (eaf-interleave--narrow-to-subtree)
-      (with-current-buffer (eaf-interleave--find-buffer pdf-url)
-        (eaf-interleave--pdf-viewer-goto-page pdf-url pdf-page))
+  (let* ((pdf-page (string-to-number (org-entry-get-with-inheritance eaf-interleave--page-note-prop)))
+         (pdf-url (org-entry-get-with-inheritance eaf-interleave--url-prop))
+         (buffer (eaf-interleave--find-buffer pdf-url)))
+    (if buffer
+        (when (and (integerp pdf-page) (> pdf-page 0)) ; The page number needs to be a positive integer
+          (eaf-interleave--narrow-to-subtree)
+          (display-buffer-reuse-mode-window buffer '(("mode" . "eaf-interleave-pdf-mode")))
+          (with-current-buffer buffer
+            (eaf-interleave--pdf-viewer-goto-page pdf-url pdf-page)))
+      (eaf-interleave--open-file)
       )))
 
 ;;;###autoload

--- a/app/interleave/eaf-interleave.el
+++ b/app/interleave/eaf-interleave.el
@@ -127,14 +127,9 @@ e.g. if `eaf-interleave-split-direction' is 'vertical the buffer is
 split horizontally."
   :keymap eaf-interleave-mode-map
   (if eaf-interleave-mode
-      (progn
-        (setq eaf-interleave-org-buffer (current-buffer))
-        (setq eaf-interleave--window-configuration (current-window-configuration)))
+      (setq eaf-interleave-org-buffer (current-buffer))
     ;; Disable the corresponding minor mode in the PDF file too.
-    (set-window-configuration eaf-interleave--window-configuration)
-    (setq eaf-interleave--window-configuration nil)
-    (setq eaf-interleave-org-buffer nil)
-    ))
+    (setq eaf-interleave-org-buffer nil)))
 
 (defvar eaf-interleave-app-mode-map (make-sparse-keymap)
   "Keymap while command `eaf-interleave-app-mode' is active.")

--- a/app/interleave/eaf-interleave.el
+++ b/app/interleave/eaf-interleave.el
@@ -117,15 +117,7 @@ split horizontally."
   (if eaf-interleave-mode
       (progn
         (setq eaf-interleave-org-buffer (current-buffer))
-        (setq eaf-interleave--window-configuration (current-window-configuration))
-        (eaf-interleave--open-file)
-        ;; expand/show all headlines if narrowing is disabled
-        (when eaf-interleave-disable-narrowing
-          (with-current-buffer eaf-interleave-org-buffer
-            (goto-char (point-min))
-            (org-cycle-hide-drawers 'all)))
-        (eaf-interleave--go-to-page-note 1)
-        (message "EAF Interleave enabled"))
+        (setq eaf-interleave--window-configuration (current-window-configuration)))
     ;; Disable the corresponding minor mode in the PDF file too.
     (set-window-configuration eaf-interleave--window-configuration)
     (setq eaf-interleave--window-configuration nil)
@@ -384,6 +376,7 @@ buffer."
 
 (defun eaf-interleave-sync-current-note ()
   "Sync EAF buffer on current note"
+  (interactive)
   (let ((url (org-entry-get-with-inheritance eaf-interleave--url-prop)))
     (cond ((and (string-prefix-p "/" url) (string-suffix-p "pdf" url t))
            (eaf-interleave-sync-pdf-page-current))))
@@ -401,7 +394,8 @@ buffer."
           (display-buffer-reuse-mode-window buffer '(("mode" . "eaf-interleave-pdf-mode")))
           (with-current-buffer buffer
             (eaf-interleave--pdf-viewer-goto-page pdf-url pdf-page)))
-      (eaf-interleave--open-file)
+      (eaf-interleave--select-split-function)
+      (eaf-interleave--open-pdf pdf-url)
       )))
 
 ;;;###autoload


### PR DESCRIPTION
参考配置
```
(use-package eaf
  :ensure nil
  :custom
  (eaf-find-alternate-file-in-dired t)
  :diminish eaf-mode
  :bind (:map eaf-interleave-mode-map
         ("M-." . 'eaf-interleave-sync-current-note)
         ("M-p" . 'eaf-interleave-sync-previous-note)
         ("M-n" . 'eaf-interleave-sync-next-note)
         :map eaf-interleave-app-mode-map
         ("C-c M-i" . 'eaf-interleave-add-note)
         ("C-c M-o" . 'eaf-interleave-open-notes-file)
         ("C-c M-q" . 'eaf-interleave-quit))
  :config
  (add-hook 'eaf-pdf-viewer-hook 'eaf-interleave-app-mode)
  (add-hook 'eaf-browser-hook 'eaf-interleave-app-mode)
  (add-hook 'org-mode-hook 'eaf-interleave-mode)
  (setq eaf-interleave-org-notes-dir-list '("~/org/interleave/"))
  (setq eaf-interleave-split-direction 'vertical)
  (setq eaf-interleave-disable-narrowing t)
  (setq eaf-interleave-split-lines 20))
```
效果图
![deepin-screen-recorder_emacs_20200404184238](https://user-images.githubusercontent.com/46041665/78425178-abaacb80-76a5-11ea-80f2-4183aab5322b.gif)

