### PR TITLE
Fix horizontal scrolling into a smooth movement

### DIFF
--- a/app/pdf-viewer/buffer.py
+++ b/app/pdf-viewer/buffer.py
@@ -441,10 +441,14 @@ class PdfViewerWidget(QWidget):
         if not event.accept():
             if event.angleDelta().y():
                 self.update_scroll_offset(max(min(self.scroll_offset - self.scale * event.angleDelta().y() / 120 * self.mouse_scroll_offset, self.max_scroll_offset()), 0))
-            elif event.angleDelta().x() >= 0:
-                self.scroll_left()
-            elif event.angleDelta().x() < 0:
-                self.scroll_right()
+            if event.angleDelta().x():
+                new_pos = (self.horizontal_offset
+                           + self.scale * event.angleDelta().x() / 120
+                           * self.mouse_scroll_offset)
+                max_pos = (self.page_width * self.scale
+                           - self.rect().width())
+                self.update_horizontal_offset(
+                    max(min(new_pos , max_pos), -max_pos))
 
     def get_start_page_index(self):
         return int(self.scroll_offset * 1.0 / self.scale / self.page_height)


### PR DESCRIPTION
It fixes some issues with the horizontal scrolling (for some reasons, scrolling with the mouse vertically would reset the horizontal scroll). I also added a smooth horizontal scroll (using the same idea as the vertical scroll). It seems to work pretty well now when you scroll either horizontally or vertically.

It's still not perfect however when you scroll both at the same time (it's a bit choppy and tends to favorize one direction over the other), but it's much easier to follow now. I guess it's a "feature" of the event QEvent object, but in our case it makes diagonal scrolling choping.