### PR TITLE
Prevent buffer name collision

### DIFF
--- a/eaf.el
+++ b/eaf.el
@@ -1311,7 +1311,7 @@ of `eaf--buffer-app-name' inside the EAF buffer."
               (setq mode-name (concat "EAF/" eaf--buffer-app-name))
               (setq-local eaf--bookmark-title title)
               (setq-local eaf--buffer-url url)
-              (rename-buffer (format eaf-buffer-title-format title))
+              (rename-buffer (format eaf-buffer-title-format title) t)
               (throw 'find-buffer t))))))))
 
 (dbus-register-signal


### PR DESCRIPTION
Prevent buffer name collision by demanding unique buffer name.

When having opened _WEB PAGE 1_ in EAF browser _BUFFER 1_, opening
_WEB PAGE 1_ from another EAF browser buffer results in error.

Passing `t` as a second argument to `rename-buffer` will suffix
duplicate buffer names with `<NUM>`.