### PR TITLE
完善 evil 集成

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -187,9 +187,13 @@ Markdown预览程序依赖grip，你需要访问[Github Personal access token](h
 
 ### evil 集成
 
-eaf 默认开启了对 evil 的支持.
-当你打开`eaf`窗口，会切换到`evil-emacs-state`, 此时按键完全由`eaf`接管。
-doom-emacs和spacemacs用户可以通过 `Esc` 回到 normal state, 使用 `Leader` 键。
+开启办法：
+```elisp
+（require 'evil-eaf）
+```
+
+evil-eaf 会动态查询 eaf 应用的按键绑定, 使得 evil 在 normal 模式下也能够很好的支持 eaf 应用。
+
 
 
 ## EAF社区

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -188,10 +188,8 @@ Markdown预览程序依赖grip，你需要访问[Github Personal access token](h
 ### evil 集成
 
 eaf 默认开启了对 evil 的支持.
-当你需绑定按键，可以直接使用
-```
-(eaf-bind-key scroll_up "C-n" eaf-pdf-viewer-keybinding)
-```
+当你打开`eaf`窗口，会切换到`evil-emacs-state`, 此时按键完全由`eaf`接管。
+doom-emacs和spacemacs用户可以通过 `Esc` 回到 normal state, 使用 `Leader` 键。
 
 
 ## EAF社区

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -185,6 +185,15 @@ Markdown预览程序依赖grip，你需要访问[Github Personal access token](h
 (setq eaf-proxy-type "socks5")
 ```
 
+### evil 集成
+
+eaf 默认开启了对 evil 的支持.
+当你需绑定按键，可以直接使用
+```
+(eaf-bind-key scroll_up "C-n" eaf-pdf-viewer-keybinding)
+```
+
+
 ## EAF社区
 
 下面列表列展示了EAF在Emacs社区的应用。如果我们遗漏你的应用，欢迎提交PR来加到下面列表中。

--- a/eaf.el
+++ b/eaf.el
@@ -2077,67 +2077,6 @@ Make sure that your smartphone is connected to the same WiFi network as this com
     (other-window -1)
     (apply orig-fun direction line args)))
 
-
-;;;;;;;;;;;;;;;;;;;; evil ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;    
-(defvar eaf-printable-character
-  (mapcar #'char-to-string (number-sequence ?! ?~))
-  "printable character")
-
-(defvar eaf-last-focus-buffer nil "")
-
-(defvar eaf-evil-init-state 'evil-normal-state
-  "when you forst enter or go back to the old buffer, eaf set this evil mode state")
-
-(defun eaf-evil-lookup-key (key)
-  (or (lookup-key (current-local-map) (kbd key))
-      (lookup-key eaf-mode-map* (kbd key))
-      ;; sequence key
-      (when (or (string-prefix-p "C-" key)
-                (string-prefix-p "M-" key))
-        (lookup-key (current-global-map) (kbd key)))
-      'eaf-send-key))
-
-(defun eaf-generate-normal-state-key-func (key)
-  (lambda () (interactive)
-    (when (not (or (evil-insert-state-p)
-                   (evil-emacs-state-p)))
-      (evil-emacs-state))
-    (call-interactively (eaf-evil-lookup-key key))))
-
-(defun eaf-evil-define-single-keys ()
-  (dolist (key (append  eaf-printable-character
-                        '("RET" "DEL" "TAB" "SPC" "<backtab>" "<home>" "<end>" "<left>" "<right>" "<up>" "<down>" "<prior>" "<next>" "<delete>" "<backspace>" "<return>")))
-    (evil-define-key* 'normal eaf-mode-map* (kbd key)
-      (eaf-generate-normal-state-key-func key))))
-
-(defun eaf-evil-define-ctrl-keys ()
-  (dolist (key (seq-difference  eaf-printable-character
-                                (mapcar #'char-to-string "wWxXcChH[1234567890")))
-    (evil-define-key* 'normal eaf-mode-map* (kbd (format "C-%s" key))
-      (eaf-generate-normal-state-key-func (format "C-%s" key)))))
-
-
-(defun eaf-evil-define-meta-keys ()
-  (dolist (key (seq-difference  eaf-printable-character
-                                (mapcar #'char-to-string "xX::1234567890")))
-    (evil-define-key* 'normal eaf-mode-map* (kbd (format "M-%s" key))
-      (eaf-generate-normal-state-key-func (format "M-%s" key)))))
-
-(defun eaf-enable-evil-intergration ()
-  (interactive)
-  (when (featurep 'evil)
-    ;; make sure you can use h,j,k,l and other often used key  in normal sate
-    (eaf-evil-define-single-keys)
-    (eaf-evil-define-ctrl-keys)
-    (eaf-evil-define-meta-keys)
-    (add-to-list 'evil-insert-state-modes 'eaf-edit-mode)
-    (evil-define-key* 'emacs eaf-mode-map* (kbd "<escape>") 'evil-normal-state)
-    ;; (add-hook 'buffer-list-update-hook #'eaf-buffer-focus-handler)
-    ))
-
-(with-eval-after-load "evil"
-  (eaf-enable-evil-intergration))
-
 (provide 'eaf)
 
 ;;; eaf.el ends here

--- a/evil-eaf.el
+++ b/evil-eaf.el
@@ -1,0 +1,103 @@
+;; evil-eaf.el --- Emacs application framework  -*- lexical-binding: t; -*-
+
+;; Filename: evil-eaf.el
+;; Description: Emacs application framework
+;; Author:  lee <loyalpartner@163.com>
+;; Maintainer: Andy Stewart <lazycat.manatee@gmail.com>
+;; Copyright (C) 2018, Andy Stewart, all rights reserved.
+;; Created: 2020-05-17 12:31:12
+;; Version: 0.5
+;; Last-Updated: Wed May 13 10:59:10 2020 (-0400)
+;;           By: Lee
+;; URL: http://www.emacswiki.org/emacs/download/eaf.el
+;; Keywords:
+;; Compatibility: GNU Emacs 27.0.50
+;;
+;; Features that might be required by this library:
+;;
+;; Please check README
+;;
+
+;;; This file is NOT part of GNU Emacs
+
+;;; License
+;;
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program; see the file COPYING.  If not, write to
+;; the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+;; Floor, Boston, MA 02110-1301, USA.
+
+(defvar eaf-printable-character
+  (mapcar #'char-to-string (number-sequence ?! ?~))
+  "printable character")
+
+(defun eaf-evil-lookup-key (key)
+  (or (lookup-key (current-local-map) (kbd key))
+      (lookup-key eaf-mode-map* (kbd key))
+      ;; sequence key
+      (when (or (string-prefix-p "C-" key)
+                (string-prefix-p "M-" key))
+        (lookup-key (current-global-map) (kbd key)))
+      'eaf-send-key))
+
+
+(defun eaf-generate-normal-state-key-func (key)
+  (lambda () (interactive)
+    (call-interactively (eaf-evil-lookup-key key))))
+
+(defun eaf-evil-define-single-keys ()
+  (dolist (key (append  eaf-printable-character
+                        '("<escape>" "RET" "DEL" "TAB" "SPC" "<backtab>" "<home>" "<end>" "<left>" "<right>" "<up>" "<down>" "<prior>" "<next>" "<delete>" "<backspace>" "<return>")))
+    (evil-define-key* '(normal insert) eaf-mode-map* (kbd key)
+      (eaf-generate-normal-state-key-func key))))
+
+(defun eaf-evil-define-ctrl-keys ()
+  (dolist (key (seq-difference  eaf-printable-character
+                                (mapcar #'char-to-string "wWxXcChH[1234567890")))
+    (evil-define-key* '(normal insert) eaf-mode-map* (kbd (format "C-%s" key))
+      (eaf-generate-normal-state-key-func (format "C-%s" key)))))
+
+
+(defun eaf-evil-define-meta-keys ()
+  (dolist (key (seq-difference  eaf-printable-character
+                                (mapcar #'char-to-string "xX::1234567890")))
+    (evil-define-key* '(normal insert) eaf-mode-map* (kbd (format "M-%s" key))
+      (eaf-generate-normal-state-key-func (format "M-%s" key)))))
+
+(defun eaf-browser-focus-p ()
+  (eq (eaf-call "call_function" eaf--buffer-id "is_focus") t))
+
+(defun eaf-browser-focus-handler ()
+  (if (eaf-browser-focus-p)
+      (unless (evil-insert-state-p) (evil-insert-state))
+    (when (evil-insert-state-p) (evil-normal-state))))
+
+(defun eaf-enable-evil-intergration ()
+  (interactive)
+  (when (featurep 'evil)
+    (eaf-evil-define-single-keys)
+    (eaf-evil-define-ctrl-keys)
+    (eaf-evil-define-meta-keys)
+    (add-to-list 'evil-insert-state-modes 'eaf-edit-mode)
+    (eaf-bind-key clear_focus "<escape>" eaf-browser-keybinding)
+    (add-hook 'eaf-browser-hook (lambda () (add-hook 'post-command-hook #'eaf-browser-focus-handler nil t)))
+    ;; TODO: add 'eaf-terminal-hook
+    ;; (add-hook 'eaf-mode-hook (lambda () ()
+    ;;                            (when (string= "terminal" eaf--buffer-app-name)
+    ;;                                 (evil-emacs-state))))
+    ))
+
+(with-eval-after-load "evil"
+  (eaf-enable-evil-intergration))
+
+(provide 'evil-eaf)


### PR DESCRIPTION
1. 默认自动集成 evil
(with-eval-after-load "evil"
  (eaf-enable-evil-intergration))
2.  保持 evil-normal-state 和 eaf 按键一致，能够在 eaf 和 其他buffer 无缝切换