### PR TITLE
PDF: exclude images in dark mode

### DIFF
--- a/app/pdf-viewer/buffer.py
+++ b/app/pdf-viewer/buffer.py
@@ -320,6 +320,18 @@ class PdfViewerWidget(QWidget):
         if self.inverted_mode:
             pixmap.invertIRect(pixmap.irect)
 
+            # exclude images
+            imagelist = page.getImageList()
+            for image in imagelist:
+                try:
+                    # image[7] is the name of the picture
+                    imagerect = page.getImageBbox(image[7])
+                    if imagerect.isInfinite or imagerect.isEmpty:
+                        continue
+                    pixmap.invertIRect(imagerect * self.scale)
+                except Exception:
+                    pass
+
         img = QImage(pixmap.samples, pixmap.width, pixmap.height, pixmap.stride, QImage.Format_RGB888)
         qpixmap = QPixmap.fromImage(img)
 


### PR DESCRIPTION
When dark mode is on, after the whole pdf is inverted, this feature is achieved by reinverting the locations where images appear.

Examples:
![image](https://user-images.githubusercontent.com/43995067/84397468-9c408500-abf6-11ea-99fb-8242b332e506.png)
