### PR TITLE
Terminal: Fix error in connection establishment: net::ERR_CONNECTION_REFUSED

### DIFF
--- a/app/terminal/index.html
+++ b/app/terminal/index.html
@@ -33,7 +33,12 @@
         <div id="xterm" class="xterm"/>
 
         <script>
-         var socket = new WebSocket("ws://127.0.0.1:%1");
+        try {
+             var socket = new WebSocket("ws://127.0.0.1:%1");
+        }
+        catch(err) {
+            setTimeout('location.reload();',1000);
+        }
          const term = new Terminal({
              fontSize: "%4",
              cursorBlink: true,


### PR DESCRIPTION
Successfully reproducing this bug:
![image](https://user-images.githubusercontent.com/43995067/86306609-4d12d080-bc47-11ea-8cff-e2c30301ecec.png)

When having this situation, you can still access the terminal by click the right button of the mouse, in the menu clicking `reload`, and then everything works fine.

So I believe this bug is caused by loading the web page too early , and I made a exception handling, when this happens, refresh the page automaticly after 1 second, and that bug never happens again.