### PR TITLE
Terminal: Close terminal buffer with EXIT signal

### DIFF
--- a/app/terminal/index.html
+++ b/app/terminal/index.html
@@ -121,7 +121,16 @@
 
              window.addEventListener("resize", sendSizeToServer);
          }
-         socket.onclose = () => {}
+
+         socket.onmessage = (msg) => {
+            if(msg==="Closing"){
+                socket.close();
+            }
+         }
+         
+         socket.onclose = () => {
+            window.close();
+         }
          socket.onerror = () => {}
         </script>
     </body>

--- a/app/terminal/server.js
+++ b/app/terminal/server.js
@@ -1,7 +1,9 @@
 this.Pty = require("node-pty");
 this.Websocket = require("ws").Server;
 
-this.onclosed = () => {};
+this.onclosed = () => {
+    ws.send("Closing");
+};
 this.onopened = () => {};
 this.onresize = () => {};
 this.ondisconnected = () => {};


### PR DESCRIPTION
When the server is about to close, it will send "Closing" to the front-end. Then on receiving that infomation, the front-end will close using `window.close()`