### PR TITLE
Terminal: Catch change directory signal in node-pty, rename terminal buffer and change Emacs default-directory variable real-time

### DIFF
--- a/app/terminal/buffer.py
+++ b/app/terminal/buffer.py
@@ -61,6 +61,10 @@ class AppBuffer(BrowserBuffer):
         QTimer.singleShot(250, self.focus_terminal)
 
         self.build_all_methods(self)
+        
+        self.timer=QTimer()
+        self.timer.start(250)
+        self.timer.timeout.connect(self.on_change_directory)
 
     def focus_terminal(self):
         event = QMouseEvent(QEvent.MouseButtonPress, QPointF(0, 0), Qt.LeftButton, Qt.LeftButton, Qt.NoModifier)
@@ -76,10 +80,12 @@ class AppBuffer(BrowserBuffer):
             html = f.read().replace("%1", str(self.port)).replace("%2", "file://" + os.path.join(os.path.dirname(__file__))).replace("%3", theme).replace("%4", self.emacs_var_dict["eaf-terminal-font-size"])
             self.buffer_widget.setHtml(html)
 
+    def on_change_directory(self):
+        self.update_title()
+        self.eval_in_emacs.emit('''(setq command-line-default-directory "'''+self.buffer_widget.execute_js("title")+'''")''')
+
     def update_title(self):
-        # FIXME: rename title based on pwd
-        # self.change_title("")
-        pass
+        self.change_title(self.buffer_widget.execute_js("title"))
 
     def destroy_buffer(self):
         os.kill(self.background_process.pid, signal.SIGKILL)

--- a/app/terminal/buffer.py
+++ b/app/terminal/buffer.py
@@ -82,7 +82,7 @@ class AppBuffer(BrowserBuffer):
 
     def on_change_directory(self):
         self.update_title()
-        self.eval_in_emacs.emit('''(setq command-line-default-directory "'''+self.buffer_widget.execute_js("title")+'''")''')
+        self.eval_in_emacs.emit('''(setq default-directory "'''+self.buffer_widget.execute_js("title")+'''")''')
 
     def update_title(self):
         self.change_title(self.buffer_widget.execute_js("title"))

--- a/app/terminal/buffer.py
+++ b/app/terminal/buffer.py
@@ -42,6 +42,7 @@ class AppBuffer(BrowserBuffer):
         arguments_dict = json.loads(arguments)
         self.command = arguments_dict["command"]
         self.start_directory = arguments_dict["directory"]
+        self.current_directory = self.start_directory
         self.index_file = os.path.join(os.path.dirname(__file__), "index.html")
         self.server_js = os.path.join(os.path.dirname(__file__), "server.js")
 
@@ -77,12 +78,15 @@ class AppBuffer(BrowserBuffer):
            (self.emacs_var_dict["eaf-terminal-dark-mode"] == "" and self.emacs_var_dict["eaf-emacs-theme-mode"] == "dark"):
             theme = "dark"
         with open(self.index_file, "r") as f:
-            html = f.read().replace("%1", str(self.port)).replace("%2", "file://" + os.path.join(os.path.dirname(__file__))).replace("%3", theme).replace("%4", self.emacs_var_dict["eaf-terminal-font-size"])
+            html = f.read().replace("%1", str(self.port)).replace("%2", "file://" + os.path.join(os.path.dirname(__file__))).replace("%3", theme).replace("%4", self.emacs_var_dict["eaf-terminal-font-size"]).replace("%5", self.current_directory)
             self.buffer_widget.setHtml(html)
 
     def on_change_directory(self):
-        self.update_title()
-        self.eval_in_emacs.emit('''(setq default-directory "'''+self.buffer_widget.execute_js("title")+'''")''')
+        changed_directory = self.buffer_widget.execute_js("title")
+        if not str(changed_directory) == self.current_directory:
+            self.update_title()
+            self.eval_in_emacs.emit('''(setq default-directory "'''+ str(changed_directory) +'''")''')
+            self.current_directory = str(changed_directory)
 
     def update_title(self):
         self.change_title(self.buffer_widget.execute_js("title"))

--- a/app/terminal/index.html
+++ b/app/terminal/index.html
@@ -44,6 +44,9 @@
              cursorBlink: true,
              theme: theme
          });
+         
+         var title = "~/"
+         
          const searchAddon = new SearchAddon.SearchAddon();
 
          function get_selection() {
@@ -123,7 +126,13 @@
          }
 
          socket.onmessage = (msg) => {
-             if(msg==="Closing"){
+         var re = /:([^\x07]*?)\x07/g;
+             arr = re.exec(msg.data)
+             if(arr) {
+                 title = arr[1]+"/";
+             }
+            
+             if(msg==="Closing") {
                  socket.close();
              }
          }

--- a/app/terminal/index.html
+++ b/app/terminal/index.html
@@ -45,7 +45,7 @@
              theme: theme
          });
          
-         var title = "~/"
+         var title = "%5"
          
          const searchAddon = new SearchAddon.SearchAddon();
 
@@ -126,13 +126,18 @@
          }
 
          socket.onmessage = (msg) => {
-         var re = /:([^\x07]*?)\x07/g;
+             var re = /:([^\x07].*?)\x07/g;
              arr = re.exec(msg.data)
              if(arr) {
-                 title = arr[1]+"/";
+                 if (arr[1] === "/") {
+                     title = arr[1];
+                 }
+                 else {
+                     title = arr[1]+"/"
+                 }
              }
             
-             if(msg==="Closing") {
+             if(msg === "Closing") {
                  socket.close();
              }
          }


### PR DESCRIPTION
When you change the directory, sever sends a mesage to the front-end. Here is an example of the message sent when you change your directory into `~`:
`]0;hollowman@hollow-manjaro:~[01;32m[hollowman@hollow-manjaro[01;37m ~[01;32m]$`

So I use regular expression `/:([^\x07].*?)\x07/g` to extract the directory infomation when that signal occurs and store it in variable `title`.
 > ~~]0;hollowman@hollow-manjaro:~~ `~` ~~[01;32m[hollowman@hollow-manjaro[01;37m \~[01;32m]$~~ 

`AppBuffer`(Buffer.py) keep checking the `title` variable every 250ms, if it detects any change, `on_change_directory` method will set the title and Emacs default directory.