### PR TITLE
Mindmap: Enter color from the keyboard to change node color.

### DIFF
--- a/app/mindmap/buffer.py
+++ b/app/mindmap/buffer.py
@@ -88,6 +88,14 @@ class AppBuffer(BrowserBuffer):
         setattr(self, method_name, _do)
 
     @interactive(insert_or_do=True)
+    def change_background_color(self):
+        self.send_input_message("Change node background color(Input color): ", "change_background_color")
+
+    @interactive(insert_or_do=True)
+    def change_text_color(self):
+        self.send_input_message("Change node text color(Input color): ", "change_text_color")
+
+    @interactive(insert_or_do=True)
     def copy_node_topic(self):
         node_topic = self.buffer_widget.execute_js("get_node_topic();")
         self.eval_in_emacs.emit('''(kill-new "{}")'''.format(node_topic))
@@ -145,6 +153,10 @@ class AppBuffer(BrowserBuffer):
         elif result_type == "change_node_background":
             print(str(result_content))
             self.buffer_widget.eval_js("change_node_background('{}');".format(str(result_content)))
+        elif result_type == "change_background_color":
+            self.buffer_widget.eval_js("change_background_color('{}');".format(str(result_content)))
+        elif result_type == "change_text_color":
+            self.buffer_widget.eval_js("change_text_color('{}');".format(str(result_content)))
 
     def is_focus(self):
         return self.buffer_widget.execute_js("node_is_focus();")

--- a/app/mindmap/index.html
+++ b/app/mindmap/index.html
@@ -20,6 +20,20 @@
              editable:true
          }
 
+         function change_background_color(color) {
+             var selected_id = get_selected_nodeid();
+             if(selected_id) {
+                 _jm.set_node_color(selected_id, color, null);
+            }
+          }
+
+         function change_text_color(color) {
+             var selected_id = get_selected_nodeid();
+             if(selected_id) {
+                _jm.set_node_color(selected_id, null, color);
+            }
+         }
+
          function select_root_node() {
              _jm.select_node("root");
          }

--- a/eaf.el
+++ b/eaf.el
@@ -547,6 +547,8 @@ Try not to modify this alist directly.  Use `eaf-setq' to modify instead."
     ("f" . "insert_or_update_node_topic")
     ("t" . "insert_or_toggle_node")
     ("b" . "insert_or_change_node_background")
+    ("c" . "insert_or_change_background_color")
+    ("C" . "insert_or_change_text_color")
     ("1" . "insert_or_save_screenshot")
     ("2" . "insert_or_save_file")
     ("3" . "insert_or_save_org_file")


### PR DESCRIPTION
This is the new design for #326 according to the feedback.

I think the new design gives users mush flexibility and it's the best than ever.

Users can input any HTML color codes instead of using a color list.

When you want to change node background color, just press 'c', and then input any format of the HTML color codes.

When you want to change node text color, just press 'C', and then input any format of the HTML color codes.

| Entering Format| Before| After|
| :--------: | :--------: | :----: |
|Color Name| <img src="https://user-images.githubusercontent.com/43995067/86501174-149b0000-bdc9-11ea-8588-89d30f48a18f.png" width="400"> |<img src="https://user-images.githubusercontent.com/43995067/86501200-54fa7e00-bdc9-11ea-8144-5e3f17cab293.png" width="400">|
|RGB Color Code| <img src="https://user-images.githubusercontent.com/43995067/86501221-8bd09400-bdc9-11ea-908f-92adec118d51.png" width="400"> |<img src="https://user-images.githubusercontent.com/43995067/86501233-a3a81800-bdc9-11ea-99f7-e7eab001ace6.png" width="400">|
|Hex Color Code| <img src="https://user-images.githubusercontent.com/43995067/86501238-b4588e00-bdc9-11ea-9841-9cdca71d21a0.png" width="400"> |<img src="https://user-images.githubusercontent.com/43995067/86501245-c89c8b00-bdc9-11ea-89d2-0cfce339014c.png" width="400">|
