### PR TITLE
fix bug in #325 change request.

### DIFF
--- a/app/terminal/buffer.py
+++ b/app/terminal/buffer.py
@@ -94,6 +94,7 @@ class AppBuffer(BrowserBuffer):
     def destroy_buffer(self):
         os.kill(self.background_process.pid, signal.SIGKILL)
         super().destroy_buffer()
+        self.timer.stop()
 
     @interactive()
     def copy_text(self):


### PR DESCRIPTION
Fix bug in #325 [change request](https://github.com/manateelazycat/emacs-application-framework/pull/325#discussion_r449729229).
> 这个timer要在buffer destroy以后取消计时器，要不是Emacs会报错：
> 
> [EAF] Killed 54ab-347e-492b-c905-3201-aa3d-fdbc.
> [EAF] Killed 0aec-a9cf-9048-13f3-8de6-132f-c8e0.
> [EAF] Killed 2 EAF buffers
> [EAF] _eaf_ 已杀死
> [EAF] Process terminated.
> apply: Setting current directory: 没有那个文件或目录, None
> Mark set [2 times]
> Error running timer: (file-missing "Setting current directory" "没有那个文件或目录" "None") [2 times]

