### PR TITLE
Terminal: Rewrite #324, add support for indicating ssh and program running in terminal buffer name #325

### DIFF
--- a/app/terminal/buffer.py
+++ b/app/terminal/buffer.py
@@ -85,56 +85,31 @@ class AppBuffer(BrowserBuffer):
             self.buffer_widget.setHtml(html)
 
     def update_title(self):
-        changed_directory = str(self.buffer_widget.execute_js("title"))
+        changed_directory = str(self.buffer_widget.execute_js("current_directory"))
         changed_destination = str(self.buffer_widget.execute_js("current_destination"))
-        changed_executing_command = ""
-        raw_message = str(self.buffer_widget.execute_js("executing_command")).split(" ",2)
-        if raw_message[0] == "sudo":
-            changed_executing_command = "sudo " + raw_message[1]
+        changed_executing_command = str(self.buffer_widget.execute_js("executing_command"))
+        if len(changed_executing_command) > 30:
+            changed_executing_command = changed_executing_command[:30]
+        if changed_executing_command != self.executing_command and self.executing_command == "":
+            self.change_title(changed_executing_command)
         else:
-            changed_executing_command = raw_message[0]
-        if changed_executing_command != self.executing_command:
-            if changed_destination == self.host_destination:
-                if changed_executing_command:
-                    self.change_title(changed_executing_command + "- " + changed_directory)
-                else:
-                    self.change_title(changed_directory)
-                self.eval_in_emacs.emit('''(setq default-directory "'''+ changed_directory +'''")''')
-            else:
-                if changed_executing_command:
-                    self.change_title(changed_executing_command + "- " + changed_destination+ ":" +changed_directory)
-                else:
-                    self.change_title(changed_destination+ ":" +changed_directory)  
-        else:
-            if not changed_directory == self.current_directory: 
+            if not changed_directory == self.current_directory or changed_executing_command != self.executing_command: 
                 if changed_destination == self.host_destination:
-                    if changed_executing_command:
-                        self.change_title(changed_executing_command + "- " +changed_directory)
-                    else:
-                        self.change_title(changed_directory)
+                    self.change_title(changed_directory)
                     self.eval_in_emacs.emit('''(setq default-directory "'''+ changed_directory +'''")''')
                 else:
-                    if changed_executing_command:
-                        self.change_title(changed_executing_command + "- "+ changed_destination+ ":" +changed_directory)
-                    else:
-                        self.change_title(changed_destination+ ":" +changed_directory)
+                    self.change_title(changed_destination+ ":" +changed_directory)
             else:
                 if not changed_destination == self.host_destination:
                     if not changed_destination == self.current_destination: 
-                        if changed_executing_command:
-                            self.change_title(changed_executing_command + "- "+ changed_destination+ ":" +changed_directory)
-                        else:
-                            self.change_title(changed_destination+ ":" +changed_directory)
+                        self.change_title(changed_destination+ ":" +changed_directory)
                 else:
                     if not changed_destination == self.current_destination: 
-                        if changed_executing_command:
-                            self.change_title(changed_executing_command + "- "+ changed_directory)
-                        else:
-                            self.change_title(changed_directory)
+                        self.change_title(changed_directory)
                         self.eval_in_emacs.emit('''(setq default-directory "'''+ changed_directory +'''")''')
+        self.executing_command = changed_executing_command
         self.current_destination = changed_destination
-        self.current_directory = changed_directory
-        self.executing_command = changed_executing_command   
+        self.current_directory = changed_directory 
 
     def destroy_buffer(self):
         os.kill(self.background_process.pid, signal.SIGKILL)

--- a/app/terminal/buffer.py
+++ b/app/terminal/buffer.py
@@ -48,6 +48,7 @@ class AppBuffer(BrowserBuffer):
         self.server_js = os.path.join(os.path.dirname(__file__), "server.js")
         self.host_destination = str(getpass.getuser())+"@"+str(socket.gethostname())
         self.current_destination = self.host_destination
+        self.executing_command = ""
         self.buffer_widget.titleChanged.connect(self.change_title)
 
         # Start server process.
@@ -67,7 +68,7 @@ class AppBuffer(BrowserBuffer):
         
         self.timer=QTimer()
         self.timer.start(250)
-        self.timer.timeout.connect(self.on_change_address)
+        self.timer.timeout.connect(self.update_title)
 
     def focus_terminal(self):
         event = QMouseEvent(QEvent.MouseButtonPress, QPointF(0, 0), Qt.LeftButton, Qt.LeftButton, Qt.NoModifier)
@@ -83,26 +84,57 @@ class AppBuffer(BrowserBuffer):
             html = f.read().replace("%1", str(self.port)).replace("%2", "file://" + os.path.join(os.path.dirname(__file__))).replace("%3", theme).replace("%4", self.emacs_var_dict["eaf-terminal-font-size"]).replace("%5", self.current_directory).replace("%6", self.host_destination)
             self.buffer_widget.setHtml(html)
 
-    def on_change_address(self):
-        changed_directory = self.buffer_widget.execute_js("title")
-        changed_destination = self.buffer_widget.execute_js("current_destination")
-        if not str(changed_directory) == self.current_directory: 
-            if str(changed_destination) == self.host_destination:
-                self.update_title()
-                self.eval_in_emacs.emit('''(setq default-directory "'''+ str(changed_directory) +'''")''')
-                self.current_directory = str(changed_directory)
-            else:
-                self.change_title("ssh- " + str(changed_destination)+ ":" +str(changed_directory))
-                self.current_directory = str(changed_directory)
-                self.current_destination = str(changed_destination)
-        else:
-            if not str(changed_destination) == self.host_destination:
-                if not str(changed_destination) == self.current_destination: 
-                    self.change_title("ssh- " + str(changed_destination)+ ":" +str(changed_directory))
-                    self.current_destination = str(changed_destination)
-
     def update_title(self):
-        self.change_title(self.buffer_widget.execute_js("title"))
+        changed_directory = str(self.buffer_widget.execute_js("title"))
+        changed_destination = str(self.buffer_widget.execute_js("current_destination"))
+        changed_executing_command = ""
+        raw_message = str(self.buffer_widget.execute_js("executing_command")).split(" ",2)
+        if raw_message[0] == "sudo":
+            changed_executing_command = "sudo " + raw_message[1]
+        else:
+            changed_executing_command = raw_message[0]
+        if changed_executing_command != self.executing_command:
+            if changed_destination == self.host_destination:
+                if changed_executing_command:
+                    self.change_title(changed_executing_command + "- " + changed_directory)
+                else:
+                    self.change_title(changed_directory)
+                self.eval_in_emacs.emit('''(setq default-directory "'''+ changed_directory +'''")''')
+            else:
+                if changed_executing_command:
+                    self.change_title(changed_executing_command + "- " + changed_destination+ ":" +changed_directory)
+                else:
+                    self.change_title(changed_destination+ ":" +changed_directory)  
+        else:
+            if not changed_directory == self.current_directory: 
+                if changed_destination == self.host_destination:
+                    if changed_executing_command:
+                        self.change_title(changed_executing_command + "- " +changed_directory)
+                    else:
+                        self.change_title(changed_directory)
+                    self.eval_in_emacs.emit('''(setq default-directory "'''+ changed_directory +'''")''')
+                else:
+                    if changed_executing_command:
+                        self.change_title(changed_executing_command + "- "+ changed_destination+ ":" +changed_directory)
+                    else:
+                        self.change_title(changed_destination+ ":" +changed_directory)
+            else:
+                if not changed_destination == self.host_destination:
+                    if not changed_destination == self.current_destination: 
+                        if changed_executing_command:
+                            self.change_title(changed_executing_command + "- "+ changed_destination+ ":" +changed_directory)
+                        else:
+                            self.change_title(changed_destination+ ":" +changed_directory)
+                else:
+                    if not changed_destination == self.current_destination: 
+                        if changed_executing_command:
+                            self.change_title(changed_executing_command + "- "+ changed_directory)
+                        else:
+                            self.change_title(changed_directory)
+                        self.eval_in_emacs.emit('''(setq default-directory "'''+ changed_directory +'''")''')
+        self.current_destination = changed_destination
+        self.current_directory = changed_directory
+        self.executing_command = changed_executing_command   
 
     def destroy_buffer(self):
         os.kill(self.background_process.pid, signal.SIGKILL)

--- a/app/terminal/index.html
+++ b/app/terminal/index.html
@@ -1,186 +1,182 @@
 <!DOCTYPE html>
 <html>
-    <head>
-        <meta charset="utf-8" />
-        <script type="text/javascript" src="%2/node_modules/xterm/lib/xterm.js"></script>
-        <script type="text/javascript" src="%2/node_modules/xterm-addon-attach/lib/xterm-addon-attach.js"></script>
-        <script type="text/javascript" src="%2/node_modules/xterm-addon-fit/lib/xterm-addon-fit.js"></script>
-        <script type="text/javascript" src="%2/node_modules/xterm-addon-search/lib/xterm-addon-search.js"></script>
-        <script type="text/javascript" src="%2/node_modules/xterm-addon-web-links/lib/xterm-addon-web-links.js"></script>
-        <script type="text/javascript" src="%2/%3_theme.js"></script>
-        <link rel="stylesheet" href="%2/node_modules/xterm/css/xterm.css" />
+  <head>
+    <meta charset="utf-8" />
+    <script type="text/javascript" src="%2/node_modules/xterm/lib/xterm.js"></script>
+    <script type="text/javascript" src="%2/node_modules/xterm-addon-attach/lib/xterm-addon-attach.js"></script>
+    <script type="text/javascript" src="%2/node_modules/xterm-addon-fit/lib/xterm-addon-fit.js"></script>
+    <script type="text/javascript" src="%2/node_modules/xterm-addon-search/lib/xterm-addon-search.js"></script>
+    <script type="text/javascript" src="%2/node_modules/xterm-addon-web-links/lib/xterm-addon-web-links.js"></script>
+    <script type="text/javascript" src="%2/%3_theme.js"></script>
+    <link rel="stylesheet" href="%2/node_modules/xterm/css/xterm.css" />
 
-        <style>
-         /* Make terminal fit full area of window */
-         html, body, #xterm, .xterm-screen, canvas {
-             width: 100%;
-             height: 100%;
-             padding: 0;
-             margin: 0;
-         }
+    <style>
+      /* Make terminal fit full area of window */
+      html, body, #xterm, .xterm-screen, canvas {
+          width: 100%;
+          height: 100%;
+          padding: 0;
+          margin: 0;
+      }
 
-         .xterm-viewport {
-             display: none;
-         }
+      .xterm-viewport {
+          display: none;
+      }
 
-         /* Hide scrollbar */
-         .xterm-viewport {
-             overflow: hidden !important;
-         }
-        </style>
-    </head>
-    <body>
-        <div id="xterm" class="xterm"/>
+      /* Hide scrollbar */
+      .xterm-viewport {
+          overflow: hidden !important;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="xterm" class="xterm"/>
 
-        <script>
-         try {
-             var socket = new WebSocket("ws://127.0.0.1:%1");
-         }
-         catch(err) {
-             setTimeout('location.reload();',1000);
-         }
-         const term = new Terminal({
-             fontSize: "%4",
-             cursorBlink: true,
-             theme: theme
-         });
-         
-         var title = "%5"
-         var host_destination = "%6"
-         var current_destination = "%6"
-         var executing_command = ""
-         
-         const searchAddon = new SearchAddon.SearchAddon();
+    <script>
+      try {
+          var socket = new WebSocket("ws://127.0.0.1:%1");
+      }
+      catch(err) {
+          setTimeout('location.reload();',1000);
+      }
+      const term = new Terminal({
+          fontSize: "%4",
+          cursorBlink: true,
+          theme: theme
+      });
+      
+      var current_directory = "%5"
+      var host_destination = "%6"
+      var current_destination = "%6"
+      var executing_command = ""
+      
+      const searchAddon = new SearchAddon.SearchAddon();
 
-         function get_selection() {
-             return term.getSelection();
-         }
+      function get_selection() {
+          return term.getSelection();
+      }
 
-         function paste(text) {
-             term.paste(text);
-         }
+      function paste(text) {
+          term.paste(text);
+      }
 
-         function scroll_line(number) {
-             term.scrollLines(number);
-         }
+      function scroll_line(number) {
+          term.scrollLines(number);
+      }
 
-         function scroll_page(number) {
-             term.scrollPages(number);
-         }
+      function scroll_page(number) {
+          term.scrollPages(number);
+      }
 
-         function scroll_to_begin() {
-             term.scrollToTop();
-         }
+      function scroll_to_begin() {
+          term.scrollToTop();
+      }
 
-         function scroll_to_bottom() {
-             term.scrollToBottom();
-         }
+      function scroll_to_bottom() {
+          term.scrollToBottom();
+      }
 
-         function select_all() {
-             term.selectAll();
-         }
+      function select_all() {
+          term.selectAll();
+      }
 
-         function clear_selection() {
-             term.clearSelection();
-         }
+      function clear_selection() {
+          term.clearSelection();
+      }
 
-         function find_next(text) {
-             searchAddon.findNext(text);
-         }
+      function find_next(text) {
+          searchAddon.findNext(text);
+      }
 
-         function find_prev(text) {
-             searchAddon.findPrevious(text);
-         }
+      function find_prev(text) {
+          searchAddon.findPrevious(text);
+      }
 
-         socket.onopen = () => {
-             const attachAddon = new AttachAddon.AttachAddon(socket);
-             const fitAddon = new FitAddon.FitAddon();
-             term.loadAddon(attachAddon);
-             term.loadAddon(fitAddon);
-             term.loadAddon(searchAddon);
-             term.loadAddon(new WebLinksAddon.WebLinksAddon());
-             term.open(document.getElementById('xterm'));
-             fitAddon.fit();
-             term.focus();
+      socket.onopen = () => {
+          const attachAddon = new AttachAddon.AttachAddon(socket);
+          const fitAddon = new FitAddon.FitAddon();
+          term.loadAddon(attachAddon);
+          term.loadAddon(fitAddon);
+          term.loadAddon(searchAddon);
+          term.loadAddon(new WebLinksAddon.WebLinksAddon());
+          term.open(document.getElementById('xterm'));
+          fitAddon.fit();
+          term.focus();
 
-             setTimeout(() => {
-                 sendSizeToServer();
-             }, 50);
+          setTimeout(() => {
+              sendSizeToServer();
+          }, 50);
 
-             function sendSizeToServer() {
-                 /* After window resize, make terminal fit before get term size */
-                 fitAddon.fit()
+          function sendSizeToServer() {
+              /* After window resize, make terminal fit before get term size */
+              fitAddon.fit()
 
-                 let cols = term.cols.toString();
-                 let rows = term.rows.toString();
-                 while (cols.length < 3) {
-                     cols = "0"+cols;
-                 }
-                 while (rows.length < 3) {
-                     rows = "0"+rows;
-                 }
+              let cols = term.cols.toString();
+              let rows = term.rows.toString();
+              while (cols.length < 3) {
+                  cols = "0"+cols;
+              }
+              while (rows.length < 3) {
+                  rows = "0"+rows;
+              }
 
-                 console.log("ESCAPED|-- RESIZE:"+cols+";"+rows);
+              console.log("ESCAPED|-- RESIZE:"+cols+";"+rows);
 
-                 socket.send("ESCAPED|-- RESIZE:"+cols+";"+rows);
-             }
+              socket.send("ESCAPED|-- RESIZE:"+cols+";"+rows);
+          }
 
-             window.addEventListener("resize", sendSizeToServer);
-             term.onLineFeed(() => {
-                 const buffer = term.buffer;
-                 const new_line = buffer.getLine(buffer.baseY + buffer.cursorY);
-                 if (new_line && !new_line.isWrapped) {
-                     var input_data = get_line_data(buffer, buffer.baseY + buffer.cursorY - 1);
-                     if (input_data.indexOf('$')!=-1){
-                        executing_command = input_data.slice(input_data.indexOf('$')+2)
-                        if(executing_command === "exit" && host_destination === current_destination){
-                            window.close();
-                        }
-                        if(executing_command.startsWith("cd ")){
-                            executing_command = ""
-                        }
-                     }
-                 }
-             })
-             function get_line_data(buffer, line_index) {
-                 let line = buffer.getLine(line_index);
-                 if (!line) {
-                     return;
-                 }
-                 let line_data = line.translateToString(true);
-                 while (line_index > 0 && line.isWrapped) {
-                     line = buffer.getLine(--line_index);
-                     if (!line) {
-                         break;
-                     }
-                     line_data = line.translateToString(false) + line_data;
-                 }
-                 return line_data;
-             }
-         }
+          window.addEventListener("resize", sendSizeToServer);
+          term.onLineFeed(() => {
+              const buffer = term.buffer;
+              const new_line = buffer.getLine(buffer.baseY + buffer.cursorY);
+              if (new_line && !new_line.isWrapped) {
+                  var input_data = get_line_data(buffer, buffer.baseY + buffer.cursorY - 1);
+                  if (input_data.indexOf('$')!=-1){
+                      executing_command = input_data.slice(input_data.indexOf('$')+1).trim()
+                      if(executing_command === "exit" && host_destination === current_destination){
+                          window.close();
+                      }
+                      if(executing_command.startsWith("cd ")){
+                          executing_command = ""
+                      }
+                  }
+              }
+          })
+          function get_line_data(buffer, line_index) {
+              let line = buffer.getLine(line_index);
+              if (!line) {
+                  return;
+              }
+              let line_data = line.translateToString(true);
+              while (line_index > 0 && line.isWrapped) {
+                  line = buffer.getLine(--line_index);
+                  if (!line) {
+                      break;
+                  }
+                  line_data = line.translateToString(false) + line_data;
+              }
+              return line_data;
+          }
+      }
 
-         socket.onmessage = (msg) => {
-             var ssh_re = /]0;(.*?):/g;
-             var re = /:([^\x07].*?)\x07/g;
-             ssh_arr = ssh_re.exec(msg.data)
-             arr = re.exec(msg.data)
-             if(ssh_arr) {
-                 executing_command = ""
-                 current_destination =ssh_arr[1]
-             }
-             if(arr) {
-                executing_command = ""
-                 if (arr[1] === "/") {
-                     title = arr[1];
-                 }
-                 else {
-                     title = arr[1]+"/"
-                 }
-             }
-         }
+      socket.onmessage = (msg) => {
+          console.log(msg.data)
+          var ssh_re = /;(.*?):/g;
+          var re = /:([^\x07].*?)\x07/g;
+          ssh_arr = ssh_re.exec(msg.data)
+          arr = re.exec(msg.data)
+          if(ssh_arr) {
+              executing_command = ""
+              current_destination =ssh_arr[1]
+          }
+          if(arr) {
+              executing_command = ""
+              current_directory = arr[1];
+          }
+      }
 
-         socket.onclose = () => {}
-         socket.onerror = () => {}
-        </script>
-    </body>
+      socket.onclose = () => {}
+      socket.onerror = () => {}
+    </script>
+  </body>
 </html>

--- a/app/terminal/index.html
+++ b/app/terminal/index.html
@@ -46,7 +46,9 @@
          });
          
          var title = "%5"
+         var host_destination = "%6"
          var current_destination = "%6"
+         var executing_command = ""
          
          const searchAddon = new SearchAddon.SearchAddon();
 
@@ -124,18 +126,50 @@
              }
 
              window.addEventListener("resize", sendSizeToServer);
+             term.onLineFeed(() => {
+                 const buffer = term.buffer;
+                 const new_line = buffer.getLine(buffer.baseY + buffer.cursorY);
+                 if (new_line && !new_line.isWrapped) {
+                     var input_data = get_line_data(buffer, buffer.baseY + buffer.cursorY - 1);
+                     if (input_data.indexOf('$')!=-1){
+                        executing_command = input_data.slice(input_data.indexOf('$')+2)
+                        if(executing_command === "exit" && host_destination === current_destination){
+                            window.close();
+                        }
+                        if(executing_command.startsWith("cd ")){
+                            executing_command = ""
+                        }
+                     }
+                 }
+             })
+             function get_line_data(buffer, line_index) {
+                 let line = buffer.getLine(line_index);
+                 if (!line) {
+                     return;
+                 }
+                 let line_data = line.translateToString(true);
+                 while (line_index > 0 && line.isWrapped) {
+                     line = buffer.getLine(--line_index);
+                     if (!line) {
+                         break;
+                     }
+                     line_data = line.translateToString(false) + line_data;
+                 }
+                 return line_data;
+             }
          }
 
          socket.onmessage = (msg) => {
-             
              var ssh_re = /]0;(.*?):/g;
              var re = /:([^\x07].*?)\x07/g;
              ssh_arr = ssh_re.exec(msg.data)
              arr = re.exec(msg.data)
              if(ssh_arr) {
+                 executing_command = ""
                  current_destination =ssh_arr[1]
              }
              if(arr) {
+                executing_command = ""
                  if (arr[1] === "/") {
                      title = arr[1];
                  }
@@ -143,15 +177,9 @@
                      title = arr[1]+"/"
                  }
              }
-            
-             if(msg === "Closing") {
-                 socket.close();
-             }
          }
 
-         socket.onclose = () => {
-             window.close();
-         }
+         socket.onclose = () => {}
          socket.onerror = () => {}
         </script>
     </body>

--- a/app/terminal/index.html
+++ b/app/terminal/index.html
@@ -46,6 +46,7 @@
          });
          
          var title = "%5"
+         var current_destination = "%6"
          
          const searchAddon = new SearchAddon.SearchAddon();
 
@@ -126,8 +127,14 @@
          }
 
          socket.onmessage = (msg) => {
+             
+             var ssh_re = /]0;(.*?):/g;
              var re = /:([^\x07].*?)\x07/g;
+             ssh_arr = ssh_re.exec(msg.data)
              arr = re.exec(msg.data)
+             if(ssh_arr) {
+                 current_destination =ssh_arr[1]
+             }
              if(arr) {
                  if (arr[1] === "/") {
                      title = arr[1];

--- a/app/terminal/server.js
+++ b/app/terminal/server.js
@@ -1,9 +1,7 @@
 this.Pty = require("node-pty");
 this.Websocket = require("ws").Server;
 
-this.onclosed = () => {
-    ws.send("Closing");
-};
+this.onclosed = () => {};
 this.onopened = () => {};
 this.onresize = () => {};
 this.ondisconnected = () => {};


### PR DESCRIPTION
Rewrite #324 so that the app won't exit without notification when launching it.

Add support for renaming terminal buffer under ssh, an example of terminal buffer name under ssh is provided as follows:
`user@example.com:~/`

Add support for renaming terminal buffer when running a program, an example of terminal buffer name when running a program is provided as follows:
`test- ~/`
