### PR TITLE
core: redesign eaf-*-dark-mode logic

### DIFF
--- a/app/mindmap/buffer.py
+++ b/app/mindmap/buffer.py
@@ -76,7 +76,7 @@ class AppBuffer(BrowserBuffer):
 
         color = "#FFFFFF"
         if self.emacs_var_dict["eaf-mindmap-dark-mode"] == "true" or \
-           (self.emacs_var_dict["eaf-mindmap-dark-mode"] == "" and self.emacs_var_dict["eaf-emacs-theme-mode"] == "dark"):
+           (self.emacs_var_dict["eaf-mindmap-dark-mode"] == "follow" and self.emacs_var_dict["eaf-emacs-theme-mode"] == "dark"):
             color = "#242525"
         self.buffer_widget.eval_js("init_background('{}');".format(color))
 

--- a/app/pdf-viewer/buffer.py
+++ b/app/pdf-viewer/buffer.py
@@ -90,7 +90,8 @@ class AppBuffer(Buffer):
         self.buffer_widget.scroll_offset = float(scroll_offset)
         self.buffer_widget.scale = float(scale)
         self.buffer_widget.read_mode = read_mode
-        self.buffer_widget.inverted_mode = inverted_mode == "True"
+        if self.emacs_var_dict["eaf-pdf-dark-mode"] == "ignore":
+            self.buffer_widget.inverted_mode = inverted_mode == "True"
         self.buffer_widget.update()
 
     def jump_to_page(self):
@@ -208,7 +209,8 @@ class PdfViewerWidget(QWidget):
         # Inverted mode.
         self.inverted_mode = False
         if (self.emacs_var_dict["eaf-pdf-dark-mode"] == "true" or \
-            (self.emacs_var_dict["eaf-pdf-dark-mode"] == "" and self.emacs_var_dict["eaf-emacs-theme-mode"] == "dark")):
+            ((self.emacs_var_dict["eaf-pdf-dark-mode"] == "follow" or self.emacs_var_dict["eaf-pdf-dark-mode"] == "ignore") and \
+             self.emacs_var_dict["eaf-emacs-theme-mode"] == "dark")):
             self.inverted_mode = True
 
         # mark link

--- a/app/terminal/buffer.py
+++ b/app/terminal/buffer.py
@@ -62,7 +62,7 @@ class AppBuffer(BrowserBuffer):
         QTimer.singleShot(250, self.focus_terminal)
 
         self.build_all_methods(self)
-        
+
         self.timer=QTimer()
         self.timer.start(250)
         self.timer.timeout.connect(self.checking_status)
@@ -75,7 +75,7 @@ class AppBuffer(BrowserBuffer):
     def open_terminal_page(self):
         theme = "light"
         if self.emacs_var_dict["eaf-terminal-dark-mode"] == "true" or \
-           (self.emacs_var_dict["eaf-terminal-dark-mode"] == "" and self.emacs_var_dict["eaf-emacs-theme-mode"] == "dark"):
+           (self.emacs_var_dict["eaf-terminal-dark-mode"] == "follow" and self.emacs_var_dict["eaf-emacs-theme-mode"] == "dark"):
             theme = "dark"
         with open(self.index_file, "r") as f:
             html = f.read().replace("%1", str(self.port)).replace("%2", "file://" + os.path.join(os.path.dirname(__file__))).replace("%3", theme).replace("%4", self.emacs_var_dict["eaf-terminal-font-size"]).replace("%5", self.current_directory)

--- a/core/browser.py
+++ b/core/browser.py
@@ -606,7 +606,7 @@ class BrowserBuffer(Buffer):
         ''' Return bool of whether dark mode is enabled.'''
         module_name = self.module_path.split(".")[1]
         return (self.emacs_var_dict["eaf-browser-dark-mode"] == "true" or \
-                (self.emacs_var_dict["eaf-browser-dark-mode"] == "" and self.emacs_var_dict["eaf-emacs-theme-mode"] == "dark")) \
+                (self.emacs_var_dict["eaf-browser-dark-mode"] == "follow" and self.emacs_var_dict["eaf-emacs-theme-mode"] == "dark")) \
                 and module_name in ["browser", "terminal", "mindmap", "js-video-player"] \
                 and self.url != "devtools://devtools/bundled/devtools_app.html"
 

--- a/eaf.el
+++ b/eaf.el
@@ -7,7 +7,7 @@
 ;; Copyright (C) 2018, Andy Stewart, all rights reserved.
 ;; Created: 2018-06-15 14:10:12
 ;; Version: 0.5
-;; Last-Updated: Tue Jul  7 09:59:13 2020 (-0400)
+;; Last-Updated: Tue Jul  7 16:32:12 2020 (-0400)
 ;;           By: Mingde (Matthew) Zeng
 ;; URL: http://www.emacswiki.org/emacs/download/eaf.el
 ;; Keywords:
@@ -248,11 +248,11 @@ It must defined at `eaf-browser-search-engines'."
     (eaf-browser-download-path . "~/Downloads")
     (eaf-browser-aria2-proxy-host . "")
     (eaf-browser-aria2-proxy-port . "")
-    (eaf-browser-dark-mode . "")
-    (eaf-pdf-dark-mode . "")
-    (eaf-terminal-dark-mode . "")
+    (eaf-browser-dark-mode . "follow")
+    (eaf-pdf-dark-mode . "follow")
+    (eaf-terminal-dark-mode . "follow")
     (eaf-terminal-font-size . "13")
-    (eaf-mindmap-dark-mode . "")
+    (eaf-mindmap-dark-mode . "follow")
     (eaf-mindmap-save-path . "~/Documents")
     (eaf-marker-letters . "ASDFHJKLWEOPCNM")
     (eaf-emacs-theme-mode . ""))


### PR DESCRIPTION
重新梳理`eaf-*-dark-mode`逻辑，更改为`true`，`false`，`follow`。`eaf-pdf-dark-mode`增加`ignore`。

1. `eaf-pdf-dark-mode`为`true`的时候，显示黑色主题
2. `eaf-pdf-dark-mode`为`false`的时候，显示白色主题
3. `eaf-pdf-dark-mode`为`follow`的时候，跟随Emacs主题
3. `eaf-pdf-dark-mode`为`ignore`的时候，会恢复关闭前的背景模式

Addresses #318. Below is a snippet of the wiki explaining the new logic.

```org-mode
   By default, a number of EAF apps will switch to dark mode if your current Emacs theme is dark.
   You can override the default by setting it to =true=, =false=, or =follow=, which is unchanged.
   #+BEGIN_SRC emacs-lisp
     (eaf-setq eaf-browser-dark-mode "true")
     (eaf-setq eaf-terminal-dark-mode "false")
     (eaf-setq eaf-mindmap-dark-mode "follow") ; default option
     (eaf-setq eaf-pdf-dark-mode "ignore") ; see below
   #+END_SRC
   In EAF PDF Viewer, since you can interactively toggle inverted mode using =i= (default keybinding), it has an *additional* option to be more flexible:

   When =eaf-pdf-dark-mode= is =ignore=, opening a PDF file for the first time will =follow= the current Emacs theme. Toggle inverted mode however you want, closing the buffer will record the final state of the dark mode. Next time the PDF file opens, it will restore the previous state. Therefore eaf-pdf-dark-mode will differ per file.
```

Signed-off-by: Mingde (Matthew) Zeng <matthewzmd@gmail.com>