### PR TITLE
Browser: Add CSS based Adblock plugin

### DIFF
--- a/app/browser/buffer.py
+++ b/app/browser/buffer.py
@@ -51,7 +51,7 @@ class AppBuffer(BrowserBuffer):
         self.buffer_widget.open_url_in_new_tab.connect(self.open_url_in_new_tab)
         self.buffer_widget.open_url_in_background_tab.connect(self.open_url_in_background_tab)
 
-        self.buffer_widget.urlChanged.connect(self.set_adblock)
+        self.buffer_widget.urlChanged.connect(self.set_adblocker)
 
         # Reset to default zoom when page init or url changed.
         self.reset_default_zoom()
@@ -61,6 +61,6 @@ class AppBuffer(BrowserBuffer):
         self.reset_default_zoom()
         self.url = self.buffer_widget.url().toString()
 
-    def set_adblock(self, url):
-        if self.emacs_var_dict["eaf-browser-enable-adblock"] == "true":
-            self.buffer_widget.load_adblock()
+    def set_adblocker(self, url):
+        if self.emacs_var_dict["eaf-browser-enable-adblocker"] == "true":
+            self.buffer_widget.load_adblocker()

--- a/app/browser/buffer.py
+++ b/app/browser/buffer.py
@@ -51,6 +51,8 @@ class AppBuffer(BrowserBuffer):
         self.buffer_widget.open_url_in_new_tab.connect(self.open_url_in_new_tab)
         self.buffer_widget.open_url_in_background_tab.connect(self.open_url_in_background_tab)
 
+        self.buffer_widget.urlChanged.connect(self.set_adblock)
+
         # Reset to default zoom when page init or url changed.
         self.reset_default_zoom()
         self.buffer_widget.urlChanged.connect(self.update_url)
@@ -58,3 +60,7 @@ class AppBuffer(BrowserBuffer):
     def update_url(self, url):
         self.reset_default_zoom()
         self.url = self.buffer_widget.url().toString()
+
+    def set_adblock(self, url):
+        if self.emacs_var_dict["eaf-browser-enable-adblock"] == "true":
+            self.buffer_widget.load_adblock()

--- a/core/adblock.css
+++ b/core/adblock.css
@@ -1,0 +1,115 @@
+/*
+ * This file can be used to apply a style to all web pages you view
+ * Rules without !important are overruled by author rules if the
+ * author sets any.  Rules with !important overrule author rules.
+ */
+
+/* You can find the latest version of this ad blocking css at:
+ * http://www.floppymoose.com
+ * hides many ads by preventing display of images that are inside
+ * links when the link HREF contans certain substrings.
+ */
+
+A:link[HREF*="addata"]  IMG, 
+A:link[HREF*="ad."]  IMG, 
+A:link[HREF*="ads."]  IMG, 
+A:link[HREF*="/ad"]  IMG, 
+A:link[HREF*="/A="]  IMG, 
+A:link[HREF*="/click"]  IMG, 
+A:link[HREF*="?click"]  IMG, 
+A:link[HREF*="?banner"]  IMG, 
+A:link[HREF*="=click"]  IMG, 
+A:link[HREF*="clickurl="]  IMG, 
+A:link[HREF*=".atwola."]  IMG, 
+A:link[HREF*="spinbox."]  IMG, 
+A:link[HREF*="transfer.go"]  IMG, 
+A:link[HREF*="adfarm"]  IMG, 
+A:link[HREF*="adSpace"]  IMG, 
+A:link[HREF*="adserve"]  IMG, 
+A:link[HREF*=".banner"]  IMG, 
+A:link[HREF*="bluestreak"]  IMG, 
+A:link[HREF*="doubleclick"]  IMG, 
+A:link[HREF*="/rd."]  IMG, 
+A:link[HREF*="/0AD"]  IMG, 
+A:link[HREF*=".falkag."]  IMG, 
+A:link[HREF*="trackoffer."]  IMG, 
+A:link[HREF*="casalemedia."]  IMG, 
+A:link[HREF*="valueclick."]  IMG, 
+A:link[HREF*="betterbasketball."]  IMG, 
+A:link[HREF*="sponsors.phtml"]  IMG, 
+A:link[HREF*="realgmtix.phtml"]  IMG, 
+A:link[HREF*="BurstingPipe"]  IMG,
+A:link[HREF*="ebayobjects"]  IMG,
+A:link[HREF*="tracksponsor."]  IMG { display: none ! important } 
+
+/* disable ad iframes */
+IFRAME[SRC*="addata"],
+IFRAME[SRC*="ad."],
+IFRAME[SRC*="ads."],
+IFRAME[SRC*="/ad"],
+IFRAME[SRC*="/A="],
+IFRAME[SRC*="/click"],
+IFRAME[SRC*="?click"],
+IFRAME[SRC*="?banner"],
+IFRAME[SRC*="=click"],
+IFRAME[SRC*="clickurl="],
+IFRAME[SRC*=".atwola."],
+IFRAME[SRC*="spinbox."],
+IFRAME[SRC*="transfer.go"],
+IFRAME[SRC*="adfarm"],
+IFRAME[SRC*="adSpace"],
+IFRAME[SRC*="adserve"],
+IFRAME[SRC*="adjuggler"],
+IFRAME[SRC*=".banner"],
+IFRAME[SRC*="bluestreak"],
+IFRAME[SRC*="doubleclick"],
+IFRAME[SRC*="/rd."],
+IFRAME[SRC*="/0AD"],
+IFRAME[SRC*=".falkag."], 
+IFRAME[SRC*="trackoffer."],
+IFRAME[SRC*="connextra."],
+IFRAME[ID*="merchandisingMERC"],
+IFRAME[SRC*="tracksponsor."]  { display: none ! important } 
+
+
+/* miscellaneous different blocking rules to block some stuff that gets through */
+
+A:link[onmouseover*="AdSolution"] IMG,
+*[class=sponsors],
+*[class=sp_links],
+*[class=advertising],
+*[ID=sponsors],
+*[ID=ad],
+*[ID=inlinead],
+*[ID=ad_creative],
+*[ID=contextualLinks],
+IMG[SRC*=".msads."] { display: none ! important } 
+
+
+/* turning some false positives back off */
+
+A:link[HREF*="/add"]  IMG, 
+A:link[HREF*="/adsl"] IMG,
+A:link[HREF*="thread."] IMG,
+A:link[HREF*="download."] IMG,
+A:link[HREF*="downloads."] IMG,
+A:link[HREF*="netflix.com/AddToQueue"] IMG,
+A:link[HREF*="load."], 
+A:link[HREF*="loads."], 
+IFRAME[SRC*="load."], 
+IFRAME[SRC*="loads."],
+A:link[HREF*="click.mp3"] IMG { display: inline ! important }
+
+/* Prevent flash animations from playing until you click on them. */
+object[classid$=":D27CDB6E-AE6D-11cf-96B8-444553540000"],
+object[codebase*="swflash.cab"],
+object[type="application/x-shockwave-flash"],
+embed[type="application/x-shockwave-flash"],
+embed[src$=".swf"]
+{ -moz-binding: url("http://www.floppymoose.com/clickToView.xml#ctv"); }
+
+/* 
+ * For more examples see http://www.mozilla.org/unix/customizing.html
+ */
+
+

--- a/core/adblocker.css
+++ b/core/adblocker.css
@@ -10,37 +10,37 @@
  * links when the link HREF contans certain substrings.
  */
 
-A:link[HREF*="addata"]  IMG, 
-A:link[HREF*="ad."]  IMG, 
-A:link[HREF*="ads."]  IMG, 
-A:link[HREF*="/ad"]  IMG, 
-A:link[HREF*="/A="]  IMG, 
-A:link[HREF*="/click"]  IMG, 
-A:link[HREF*="?click"]  IMG, 
-A:link[HREF*="?banner"]  IMG, 
-A:link[HREF*="=click"]  IMG, 
-A:link[HREF*="clickurl="]  IMG, 
-A:link[HREF*=".atwola."]  IMG, 
-A:link[HREF*="spinbox."]  IMG, 
-A:link[HREF*="transfer.go"]  IMG, 
-A:link[HREF*="adfarm"]  IMG, 
-A:link[HREF*="adSpace"]  IMG, 
-A:link[HREF*="adserve"]  IMG, 
-A:link[HREF*=".banner"]  IMG, 
-A:link[HREF*="bluestreak"]  IMG, 
-A:link[HREF*="doubleclick"]  IMG, 
-A:link[HREF*="/rd."]  IMG, 
-A:link[HREF*="/0AD"]  IMG, 
-A:link[HREF*=".falkag."]  IMG, 
-A:link[HREF*="trackoffer."]  IMG, 
-A:link[HREF*="casalemedia."]  IMG, 
-A:link[HREF*="valueclick."]  IMG, 
-A:link[HREF*="betterbasketball."]  IMG, 
-A:link[HREF*="sponsors.phtml"]  IMG, 
-A:link[HREF*="realgmtix.phtml"]  IMG, 
+A:link[HREF*="addata"]  IMG,
+A:link[HREF*="ad."]  IMG,
+A:link[HREF*="ads."]  IMG,
+A:link[HREF*="/ad"]  IMG,
+A:link[HREF*="/A="]  IMG,
+A:link[HREF*="/click"]  IMG,
+A:link[HREF*="?click"]  IMG,
+A:link[HREF*="?banner"]  IMG,
+A:link[HREF*="=click"]  IMG,
+A:link[HREF*="clickurl="]  IMG,
+A:link[HREF*=".atwola."]  IMG,
+A:link[HREF*="spinbox."]  IMG,
+A:link[HREF*="transfer.go"]  IMG,
+A:link[HREF*="adfarm"]  IMG,
+A:link[HREF*="adSpace"]  IMG,
+A:link[HREF*="adserve"]  IMG,
+A:link[HREF*=".banner"]  IMG,
+A:link[HREF*="bluestreak"]  IMG,
+A:link[HREF*="doubleclick"]  IMG,
+A:link[HREF*="/rd."]  IMG,
+A:link[HREF*="/0AD"]  IMG,
+A:link[HREF*=".falkag."]  IMG,
+A:link[HREF*="trackoffer."]  IMG,
+A:link[HREF*="casalemedia."]  IMG,
+A:link[HREF*="valueclick."]  IMG,
+A:link[HREF*="betterbasketball."]  IMG,
+A:link[HREF*="sponsors.phtml"]  IMG,
+A:link[HREF*="realgmtix.phtml"]  IMG,
 A:link[HREF*="BurstingPipe"]  IMG,
 A:link[HREF*="ebayobjects"]  IMG,
-A:link[HREF*="tracksponsor."]  IMG { display: none ! important } 
+A:link[HREF*="tracksponsor."]  IMG { display: none ! important }
 
 /* disable ad iframes */
 IFRAME[SRC*="addata"],
@@ -65,11 +65,11 @@ IFRAME[SRC*="bluestreak"],
 IFRAME[SRC*="doubleclick"],
 IFRAME[SRC*="/rd."],
 IFRAME[SRC*="/0AD"],
-IFRAME[SRC*=".falkag."], 
+IFRAME[SRC*=".falkag."],
 IFRAME[SRC*="trackoffer."],
 IFRAME[SRC*="connextra."],
 IFRAME[ID*="merchandisingMERC"],
-IFRAME[SRC*="tracksponsor."]  { display: none ! important } 
+IFRAME[SRC*="tracksponsor."]  { display: none ! important }
 
 
 /* miscellaneous different blocking rules to block some stuff that gets through */
@@ -83,20 +83,20 @@ A:link[onmouseover*="AdSolution"] IMG,
 *[ID=inlinead],
 *[ID=ad_creative],
 *[ID=contextualLinks],
-IMG[SRC*=".msads."] { display: none ! important } 
+IMG[SRC*=".msads."] { display: none ! important }
 
 
 /* turning some false positives back off */
 
-A:link[HREF*="/add"]  IMG, 
+A:link[HREF*="/add"]  IMG,
 A:link[HREF*="/adsl"] IMG,
 A:link[HREF*="thread."] IMG,
 A:link[HREF*="download."] IMG,
 A:link[HREF*="downloads."] IMG,
 A:link[HREF*="netflix.com/AddToQueue"] IMG,
-A:link[HREF*="load."], 
-A:link[HREF*="loads."], 
-IFRAME[SRC*="load."], 
+A:link[HREF*="load."],
+A:link[HREF*="loads."],
+IFRAME[SRC*="load."],
 IFRAME[SRC*="loads."],
 A:link[HREF*="click.mp3"] IMG { display: inline ! important }
 
@@ -108,8 +108,6 @@ embed[type="application/x-shockwave-flash"],
 embed[src$=".swf"]
 { -moz-binding: url("http://www.floppymoose.com/clickToView.xml#ctv"); }
 
-/* 
+/*
  * For more examples see http://www.mozilla.org/unix/customizing.html
  */
-
-

--- a/core/browser.py
+++ b/core/browser.py
@@ -103,8 +103,8 @@ class BrowserView(QWebEngineView):
         script.setWorldId(QWebEngineScript.ApplicationWorld)
         self.web_page.scripts().insert(script)
 
-    def load_adblock(self):
-        self.load_css(os.path.join(os.path.dirname(__file__), "adblock.css"),'adblock')
+    def load_adblocker(self):
+        self.load_css(os.path.join(os.path.dirname(__file__), "adblocker.css"),'adblocker')
 
     def remove_css(self, name, immediately):
         SCRIPT =  """
@@ -167,18 +167,18 @@ class BrowserView(QWebEngineView):
             self.web_page.findText(self.search_term)
 
     @interactive()
-    def change_adblock_status(self):
-        ''' Change adblock status.'''
-        if self.buffer.emacs_var_dict["eaf-browser-enable-adblock"] == "true":
-            self.buffer.emacs_var_dict["eaf-browser-enable-adblock"] = "false"
-            self.buffer.set_emacs_var.emit("eaf-browser-enable-adblock", "false")
-            self.remove_css('adblock',True)
-            self.buffer.message_to_emacs.emit("Successfully disabled adblock!")
-        elif self.buffer.emacs_var_dict["eaf-browser-enable-adblock"] == "false":
-            self.buffer.emacs_var_dict["eaf-browser-enable-adblock"] = "true"
-            self.buffer.set_emacs_var.emit("eaf-browser-enable-adblock", "true")
-            self.load_adblock()
-            self.buffer.message_to_emacs.emit("Successfully enabled adblock!")
+    def toggle_adblocker(self):
+        ''' Change adblocker status.'''
+        if self.buffer.emacs_var_dict["eaf-browser-enable-adblocker"] == "true":
+            self.buffer.emacs_var_dict["eaf-browser-enable-adblocker"] = "false"
+            self.buffer.set_emacs_var.emit("eaf-browser-enable-adblocker", "false")
+            self.remove_css('adblocker',True)
+            self.buffer.message_to_emacs.emit("Successfully disabled adblocker!")
+        elif self.buffer.emacs_var_dict["eaf-browser-enable-adblocker"] == "false":
+            self.buffer.emacs_var_dict["eaf-browser-enable-adblocker"] = "true"
+            self.buffer.set_emacs_var.emit("eaf-browser-enable-adblocker", "true")
+            self.load_adblocker()
+            self.buffer.message_to_emacs.emit("Successfully enabled adblocker!")
 
     @interactive()
     def search_text_forward(self):

--- a/core/browser.py
+++ b/core/browser.py
@@ -51,7 +51,6 @@ class BrowserView(QWebEngineView):
         self.installEventFilter(self)
         self.buffer_id = buffer_id
         self.config_dir = config_dir
-        self.enable_adblock = True
 
         self.web_page = BrowserPage()
         self.setPage(self.web_page)
@@ -65,9 +64,6 @@ class BrowserView(QWebEngineView):
         self.urlChanged.connect(lambda url: self.search_quit())
 
         self.load_cookie()
-
-        if self.enable_adblock:
-            self.load_css(os.path.join(os.path.dirname(__file__), "adblock.css"),'adblock')
 
         self.search_term = ""
 
@@ -106,6 +102,9 @@ class BrowserView(QWebEngineView):
         script.setRunsOnSubFrames(True)
         script.setWorldId(QWebEngineScript.ApplicationWorld)
         self.web_page.scripts().insert(script)
+
+    def load_adblock(self):
+        self.load_css(os.path.join(os.path.dirname(__file__), "adblock.css"),'adblock')
 
     def remove_css(self, name, immediately):
         SCRIPT =  """
@@ -166,17 +165,19 @@ class BrowserView(QWebEngineView):
             self.web_page.findText(self.search_term, self.web_page.FindBackward)
         else:
             self.web_page.findText(self.search_term)
-            
+
     @interactive()
     def change_adblock_status(self):
         ''' Change adblock status.'''
-        if self.enable_adblock == True:
-            self.enable_adblock = False
+        if self.buffer.emacs_var_dict["eaf-browser-enable-adblock"] == "true":
+            self.buffer.emacs_var_dict["eaf-browser-enable-adblock"] = "false"
+            self.buffer.set_emacs_var.emit("eaf-browser-enable-adblock", "false")
             self.remove_css('adblock',True)
             self.buffer.message_to_emacs.emit("Successfully disabled adblock!")
-        elif self.enable_adblock == False:
-            self.enable_adblock = True
-            self.load_css(os.path.join(os.path.dirname(__file__), "adblock.css"),'adblock')
+        elif self.buffer.emacs_var_dict["eaf-browser-enable-adblock"] == "false":
+            self.buffer.emacs_var_dict["eaf-browser-enable-adblock"] = "true"
+            self.buffer.set_emacs_var.emit("eaf-browser-enable-adblock", "true")
+            self.load_adblock()
             self.buffer.message_to_emacs.emit("Successfully enabled adblock!")
 
     @interactive()

--- a/core/browser.py
+++ b/core/browser.py
@@ -171,12 +171,12 @@ class BrowserView(QWebEngineView):
         ''' Change adblocker status.'''
         if self.buffer.emacs_var_dict["eaf-browser-enable-adblocker"] == "true":
             self.buffer.emacs_var_dict["eaf-browser-enable-adblocker"] = "false"
-            self.buffer.set_emacs_var.emit("eaf-browser-enable-adblocker", "false")
+            self.buffer.set_emacs_var.emit("eaf-browser-enable-adblocker", "false", "true")
             self.remove_css('adblocker',True)
             self.buffer.message_to_emacs.emit("Successfully disabled adblocker!")
         elif self.buffer.emacs_var_dict["eaf-browser-enable-adblocker"] == "false":
             self.buffer.emacs_var_dict["eaf-browser-enable-adblocker"] = "true"
-            self.buffer.set_emacs_var.emit("eaf-browser-enable-adblocker", "true")
+            self.buffer.set_emacs_var.emit("eaf-browser-enable-adblocker", "true", "true")
             self.load_adblocker()
             self.buffer.message_to_emacs.emit("Successfully enabled adblocker!")
 

--- a/eaf.el
+++ b/eaf.el
@@ -242,6 +242,7 @@ It must defined at `eaf-browser-search-engines'."
 (defcustom eaf-var-list
   '((eaf-camera-save-path . "~/Downloads")
     (eaf-browser-enable-plugin . "true")
+    (eaf-browser-enable-adblock . "true")
     (eaf-browser-enable-javascript . "true")
     (eaf-browser-remember-history . "true")
     (eaf-browser-default-zoom . "1.0")

--- a/eaf.el
+++ b/eaf.el
@@ -7,7 +7,7 @@
 ;; Copyright (C) 2018, Andy Stewart, all rights reserved.
 ;; Created: 2018-06-15 14:10:12
 ;; Version: 0.5
-;; Last-Updated: Thu Jul  9 19:22:50 2020 (-0400)
+;; Last-Updated: Sun Jul 12 21:48:49 2020 (-0400)
 ;;           By: Mingde (Matthew) Zeng
 ;; URL: http://www.emacswiki.org/emacs/download/eaf.el
 ;; Keywords:
@@ -242,7 +242,7 @@ It must defined at `eaf-browser-search-engines'."
 (defcustom eaf-var-list
   '((eaf-camera-save-path . "~/Downloads")
     (eaf-browser-enable-plugin . "true")
-    (eaf-browser-enable-adblock . "false")
+    (eaf-browser-enable-adblocker . "false")
     (eaf-browser-enable-javascript . "true")
     (eaf-browser-remember-history . "true")
     (eaf-browser-default-zoom . "1.0")
@@ -270,7 +270,6 @@ Try not to modify this alist directly.  Use `eaf-setq' to modify instead."
     ("C-0" . "zoom_reset")
     ("C-s" . "search_text_forward")
     ("C-r" . "search_text_backward")
-    ("C-d" . "change_adblock_status")
     ("C-n" . "scroll_up")
     ("C-p" . "scroll_down")
     ("C-f" . "scroll_right")
@@ -288,6 +287,7 @@ Try not to modify this alist directly.  Use `eaf-setq' to modify instead."
     ("M-f" . "history_forward")
     ("M-b" . "history_backward")
     ("M-q" . "clear_cookies")
+    ("M-a" . "toggle_adblocker")
     ("C-M-q" . "clear_history")
     ("M-v" . "scroll_down_page")
     ("M-<" . "scroll_to_begin")

--- a/eaf.el
+++ b/eaf.el
@@ -269,6 +269,7 @@ Try not to modify this alist directly.  Use `eaf-setq' to modify instead."
     ("C-0" . "zoom_reset")
     ("C-s" . "search_text_forward")
     ("C-r" . "search_text_backward")
+    ("C-d" . "change_adblock_status")
     ("C-n" . "scroll_up")
     ("C-p" . "scroll_down")
     ("C-f" . "scroll_right")

--- a/eaf.el
+++ b/eaf.el
@@ -242,7 +242,7 @@ It must defined at `eaf-browser-search-engines'."
 (defcustom eaf-var-list
   '((eaf-camera-save-path . "~/Downloads")
     (eaf-browser-enable-plugin . "true")
-    (eaf-browser-enable-adblock . "true")
+    (eaf-browser-enable-adblock . "false")
     (eaf-browser-enable-javascript . "true")
     (eaf-browser-remember-history . "true")
     (eaf-browser-default-zoom . "1.0")


### PR DESCRIPTION
Add the CSS-based Adblock functionality for browser.

An example of Adblock CSS is provide at `core/adblock.css` from http://www.floppymoose.com/ , users can customize their own rules.

Use `C-d` to enable or disable adblock.

Here is a demo which shows the effect of block Google ADs when enable and disable adblock at my [website](https://hollowman6.github.io/fund.html) under the provided CSS file:
![image](https://user-images.githubusercontent.com/43995067/87243870-22f1b780-c46c-11ea-83b0-cec1a4f51139.png)
![image](https://user-images.githubusercontent.com/43995067/87243875-2c7b1f80-c46c-11ea-925f-8ec1b2323b21.png)

