### PR TITLE
PDF Viewer: Make PDF background and annotate color follow emacs theme

### DIFF
--- a/app/pdf-viewer/buffer.py
+++ b/app/pdf-viewer/buffer.py
@@ -256,7 +256,10 @@ class PdfViewerWidget(QWidget):
         self.page_annotate_height = 22
         self.page_annotate_padding_right = 10
         self.page_annotate_padding_bottom = 10
-        self.page_annotate_color = QColor(self.emacs_var_dict["eaf-emacs-theme-foreground-color"])
+        self.page_annotate_light_color = QColor(self.emacs_var_dict["eaf-emacs-theme-foreground-color"])
+        self.page_annotate_dark_color = QColor(1-QColor(self.emacs_var_dict["eaf-emacs-theme-foreground-color"]).redF(),\
+                                               1-QColor(self.emacs_var_dict["eaf-emacs-theme-foreground-color"]).greenF(),\
+                                               1-QColor(self.emacs_var_dict["eaf-emacs-theme-foreground-color"]).blueF())
         self.font = QFont()
         self.font.setPointSize(12)
 
@@ -326,10 +329,7 @@ class PdfViewerWidget(QWidget):
             self.select_area_annot_cache_dict[index] = None
 
         if self.emacs_var_dict["eaf-pdf-dark-mode"] == "follow":
-            if self.inverted_mode:
-                col = self.handle_color(QColor(self.emacs_var_dict["eaf-emacs-theme-background-color"]), True)
-            else:
-                col = self.handle_color(QColor(self.emacs_var_dict["eaf-emacs-theme-background-color"]))
+            col = self.handle_color(QColor(self.emacs_var_dict["eaf-emacs-theme-background-color"]), self.inverted_mode)
             page.drawRect(page.rect, color=col, fill=col, overlay=False)
 
         trans = self.page_cache_trans if self.page_cache_trans is not None else fitz.Matrix(scale, scale)
@@ -426,7 +426,10 @@ class PdfViewerWidget(QWidget):
         # Render current page.
         painter.setFont(self.font)
 
-        painter.setPen(self.page_annotate_color)
+        if self.inverted_mode:
+            painter.setPen(self.page_annotate_dark_color)
+        else:
+            painter.setPen(self.page_annotate_light_color)
 
         painter.drawText(QRect(self.rect().x(),
                                self.rect().y() + self.rect().height() - self.page_annotate_height - self.page_annotate_padding_bottom,

--- a/eaf.el
+++ b/eaf.el
@@ -275,7 +275,9 @@ It must defined at `eaf-browser-search-engines'."
     (eaf-mindmap-dark-mode . "follow")
     (eaf-mindmap-save-path . "~/Documents")
     (eaf-marker-letters . "ASDFHJKLWEOPCNM")
-    (eaf-emacs-theme-mode . ""))
+    (eaf-emacs-theme-mode . "")
+    (eaf-emacs-theme-background-color . "")
+    (eaf-emacs-theme-foreground-color . ""))
   "The alist storing user-defined variables that's shared with EAF Python side.
 
 Try not to modify this alist directly.  Use `eaf-setq' to modify instead."
@@ -2088,13 +2090,25 @@ Make sure that your smartphone is connected to the same WiFi network as this com
 (defun eaf-get-theme-mode ()
   (format "%s"(frame-parameter nil 'background-mode)))
 
+(defun eaf-get-theme-background-color ()
+  (format "%s"(frame-parameter nil 'background-color)))
+
+(defun eaf-get-theme-foreground-color ()
+  (format "%s"(frame-parameter nil 'foreground-color)))
+
 (eaf-setq eaf-emacs-theme-mode (eaf-get-theme-mode))
+
+(eaf-setq eaf-emacs-theme-background-color (eaf-get-theme-background-color))
+
+(eaf-setq eaf-emacs-theme-foreground-color (eaf-get-theme-foreground-color))
 
 (advice-add 'load-theme :around #'eaf-monitor-load-theme)
 (defun eaf-monitor-load-theme (orig-fun &optional arg &rest args)
   "Update `eaf-emacs-theme-mode' after execute `load-theme'."
   (apply orig-fun arg args)
-  (eaf-setq eaf-emacs-theme-mode (eaf-get-theme-mode)))
+  (eaf-setq eaf-emacs-theme-mode (eaf-get-theme-mode))
+  (eaf-setq eaf-emacs-theme-background-color (eaf-get-theme-background-color))
+  (eaf-setq eaf-emacs-theme-foreground-color (eaf-get-theme-foreground-color)))
 
 (define-minor-mode eaf-pdf-outline-mode
   "EAF pdf outline mode."


### PR DESCRIPTION
Now the `page_annotate_color` will follow emacs theme foreground color, and inverted if in dark mode

When `eaf-pdf-dark-mode` is `follow`, the pdf background will be emacs theme background color.

Example:

![image](https://user-images.githubusercontent.com/43995067/88458562-84c90d00-cec1-11ea-865a-510dd056a647.png)

Signed-off-by: Hollow Man <hollowman186@vip.qq.com>