### PR TITLE
PDF-Viewer: Add restriction to PDF files only #314

### DIFF
--- a/app/pdf-viewer/buffer.py
+++ b/app/pdf-viewer/buffer.py
@@ -328,7 +328,7 @@ class PdfViewerWidget(QWidget):
             self.char_dict[index] = self.get_page_char_rect_list(index)
             self.select_area_annot_cache_dict[index] = None
 
-        if self.emacs_var_dict["eaf-pdf-dark-mode"] == "follow":
+        if self.emacs_var_dict["eaf-pdf-dark-mode"] == "follow" and self.url.split(".")[-1] == "pdf":
             col = self.handle_color(QColor(self.emacs_var_dict["eaf-emacs-theme-background-color"]), self.inverted_mode)
             page.drawRect(page.rect, color=col, fill=col, overlay=False)
 

--- a/app/pdf-viewer/buffer.py
+++ b/app/pdf-viewer/buffer.py
@@ -328,7 +328,7 @@ class PdfViewerWidget(QWidget):
             self.char_dict[index] = self.get_page_char_rect_list(index)
             self.select_area_annot_cache_dict[index] = None
 
-        if self.emacs_var_dict["eaf-pdf-dark-mode"] == "follow" and self.url.split(".")[-1] == "pdf":
+        if self.emacs_var_dict["eaf-pdf-dark-mode"] == "follow" and os.path.splitext(self.url)[-1] == ".pdf":
             col = self.handle_color(QColor(self.emacs_var_dict["eaf-emacs-theme-background-color"]), self.inverted_mode)
             page.drawRect(page.rect, color=col, fill=col, overlay=False)
 


### PR DESCRIPTION
> https://github.com/manateelazycat/emacs-application-framework/blob/83a25b83c4fc831a73a16dcdb617446a09c29507/app/pdf-viewer/buffer.py#L331
> 
> 

![image](https://user-images.githubusercontent.com/43995067/89021524-3e592f80-d353-11ea-8f9b-2a1869eaec37.png)

Since pymupdf doesn't support changing `epub` file's background currently, I add restriction so that `page.drawRect` only executes in the pdf files to solve #314 .

Signed-off-by: Hollow Man <hollowman186@vip.qq.com>