### PR TITLE
'minor-mode' for caret.

### DIFF
--- a/core/browser.py
+++ b/core/browser.py
@@ -973,56 +973,59 @@ class BrowserBuffer(Buffer):
             self.caret_browsing_activated = True
             self.caret_browsing_search_text = ""
 
+
+    @interactive()
     def caret_exit(self):
         ''' Exit caret browsing.'''
         if self.caret_browsing_activated:
             self.buffer_widget.eval_js("CaretBrowsing.shutdown();")
             self.message_to_emacs.emit("Caret browsing deactivated.")
+            self.eval_in_emacs.emit('''(eaf--toggle-caret-browsing nil)''')
             self.caret_browsing_activated = False
 
-    @interactive(insert_or_do=True)
+    @interactive()
     def caret_next_line(self):
         ''' Switch to next line in caret browsing.'''
         if self.caret_browsing_activated:
             self.buffer_widget.eval_js("CaretBrowsing.move('forward', 'line');")
 
-    @interactive(insert_or_do=True)
+    @interactive()
     def caret_previous_line(self):
         ''' Switch to previous line in caret browsing.'''
         if self.caret_browsing_activated:
             self.buffer_widget.eval_js("CaretBrowsing.move('backward', 'line');")
 
-    @interactive(insert_or_do=True)
+    @interactive()
     def caret_next_character(self):
         ''' Switch to next character in caret browsing.'''
         if self.caret_browsing_activated:
             self.buffer_widget.eval_js("CaretBrowsing.move('forward', 'character');")
 
-    @interactive(insert_or_do=True)
+    @interactive()
     def caret_previous_character(self):
         ''' Switch to previous character in caret browsing.'''
         if self.caret_browsing_activated:
             self.buffer_widget.eval_js("CaretBrowsing.move('backward', 'character');")
 
-    @interactive(insert_or_do=True)
+    @interactive()
     def caret_next_word(self):
         ''' Switch to next word in caret browsing.'''
         if self.caret_browsing_activated:
             self.buffer_widget.eval_js("CaretBrowsing.move('forward', 'word');")
             
-    @interactive(insert_or_do=True)
+    @interactive()
     def caret_previous_word(self):
         ''' Switch to previous word in caret browsing.'''
         if self.caret_browsing_activated:
             self.buffer_widget.eval_js("CaretBrowsing.move('backward', 'word');")
 
-    @interactive(insert_or_do=True)
+    @interactive()
     def caret_to_bottom(self):
         ''' Switch to next word in caret browsing.'''
         if self.caret_browsing_activated:
             self.buffer_widget.eval_js("CaretBrowsing.move('forward', 'documentboundary');")
             
-    @interactive(insert_or_do=True)
+    @interactive()
     def caret_to_top(self):
         ''' Switch to previous word in caret browsing.'''
         if self.caret_browsing_activated:
@@ -1034,9 +1037,11 @@ class BrowserBuffer(Buffer):
             self.buffer_widget.eval_js("CaretBrowsing.toggleMark();")
             if self.buffer_widget.execute_js("CaretBrowsing.markEnabled"):
                 self.caret_browsing_mark_activated = True
+                self.eval_in_emacs.emit('''(eaf--toggle-caret-browsing t)''')
                 self.message_to_emacs.emit("Mark is on.")
             else:
                 self.caret_browsing_mark_activated = False
+                self.eval_in_emacs.emit('''(eaf--toggle-caret-browsing nil)''')
                 self.message_to_emacs.emit("Mark is off.")
 
     def caret_clear_search(self):
@@ -1046,7 +1051,7 @@ class BrowserBuffer(Buffer):
                 self.caret_browsing_search_text = ""
                 self.message_to_emacs.emit("Cleared caret search text.")
 
-    @interactive(insert_or_do=True)
+    @interactive()
     def caret_search_forward(self):
         ''' Search Text forward in caret browsing.'''
         if self.caret_browsing_activated:
@@ -1056,7 +1061,7 @@ class BrowserBuffer(Buffer):
                 else:
                     self._caret_search_text(self.caret_browsing_search_text)
 
-    @interactive(insert_or_do=True)
+    @interactive()
     def caret_search_backward(self):
         ''' Search Text backward in caret browsing.'''
         if self.caret_browsing_activated:

--- a/eaf-evil.el
+++ b/eaf-evil.el
@@ -43,8 +43,8 @@
 
 ;; EAF evil Key Configuration
 (defun eaf-evil-lookup-key (key)
-  (or (lookup-key (current-local-map) (kbd key))
-      (lookup-key eaf-mode-map* (kbd key))
+  (or (lookup-key eaf-mode-map (kbd key))
+      (lookup-key (current-local-map) (kbd key))
       ;; sequence key
       (when (or (string-prefix-p "C-" key)
                 (string-prefix-p "M-" key))

--- a/eaf.el
+++ b/eaf.el
@@ -283,6 +283,34 @@ It must defined at `eaf-browser-search-engines'."
 Try not to modify this alist directly.  Use `eaf-setq' to modify instead."
   :type 'cons)
 
+(defcustom eaf-browser-caret-mode-keybinding
+  '(
+    ("/" . "caret_search_forward")
+    ("?" . "caret_search_backward")
+    ("q" . "caret_exit")
+    ("v" . "caret_exit")
+    ("C-q" . "caret_exit")
+    ("j" . "caret_next_line")
+    ("k" . "caret_previous_line")
+    ("l" . "caret_next_character")
+    ("h" . "caret_previous_character")
+    ("w" . "caret_next_word")
+    ("b" . "caret_previous_word")
+    ("g" . "caret_to_bottom")
+    ("G" . "caret_to_top")
+    ("C-s" . "caret_search_forward")
+    ("C-r" . "caret_search_backward")
+    ("C-n" . "caret_next_line")
+    ("C-p" . "caret_previous_line")
+    ("C-f" . "caret_next_character")
+    ("C-b" . "caret_previous_character")
+    ("M-f" . "caret_next_word")
+    ("M-b" . "caret_previous_word")
+    ("C-." . "caret_clear_search")
+    )
+  "The keybinding of EAF Browser Caret Mode."
+  :type 'cons)
+
 (defcustom eaf-browser-keybinding
   '(("C--" . "zoom_out")
     ("C-=" . "zoom_in")
@@ -317,19 +345,7 @@ Try not to modify this alist directly.  Use `eaf-setq' to modify instead."
     ("M->" . "scroll_to_bottom")
     ("M-t" . "new_blank_page")
     ("SPC" . "insert_or_scroll_up_page")
-    ("C-q" . "caret_exit")
-    ("s" . "insert_or_caret_next_line")
-    ("w" . "insert_or_caret_previous_line")
-    ("d" . "insert_or_caret_next_character")
-    ("a" . "insert_or_caret_previous_character")
-    ("D" . "insert_or_caret_next_word")
-    ("A" . "insert_or_caret_previous_word")
-    ("S" . "insert_or_caret_to_bottom")
-    ("W" . "insert_or_caret_to_top")
-    ("/" . "insert_or_caret_search_forward")
-    ("?" . "insert_or_caret_search_backward")
     ("C-i" . "caret_toggle_mark")
-    ("C-." . "caret_clear_search")
     ("J" . "insert_or_select_left_tab")
     ("K" . "insert_or_select_right_tab")
     ("j" . "insert_or_scroll_up")
@@ -1079,11 +1095,12 @@ Please ONLY use `eaf-bind-key' and use the unprefixed command name (\"%s\")
 to edit EAF keybindings!" fun fun)))
     sym))
 
-(defun eaf--gen-keybinding-map (keybinding)
+(defun eaf--gen-keybinding-map (keybinding &optional no-inherit-eaf-mode-map*)
   "Configure the `eaf-mode-map' from KEYBINDING, one of the eaf-.*-keybinding variables."
   (setq eaf-mode-map
         (let ((map (make-sparse-keymap)))
-          (set-keymap-parent map eaf-mode-map*)
+          (unless no-inherit-eaf-mode-map*
+            (set-keymap-parent map eaf-mode-map*))
           (cl-loop for (key . fun) in keybinding
                    do (define-key map (kbd key)
                         (cond
@@ -1096,7 +1113,14 @@ to edit EAF keybindings!" fun fun)))
                          ;; If command is string and include - , it's elisp function, use `intern' build elisp function from function name.
                          ((string-match "-" fun)
                           (intern fun))))
-                   finally return map))))
+                   finally return map)))
+  )
+
+(defun eaf--toggle-caret-browsing (caret-status)
+  (if caret-status
+      (eaf--gen-keybinding-map eaf-browser-caret-mode-keybinding t)
+    (eaf--gen-keybinding-map eaf-browser-keybinding))
+  (setq eaf--buffer-map-alist (list (cons t eaf-mode-map))))
 
 (defun eaf--get-app-bindings (app-name)
   "Get the specified APP-NAME keybinding.


### PR DESCRIPTION
fix https://github.com/manateelazycat/emacs-application-framework/pull/349

@HollowMan6  抱歉，我不会用git在你pull request下改代码，就独立弄了个pull， 并且把按键改成 vim-style 和 emacs-style 的方式,因为我觉得这种按键没有学习成本，并切 emacs 用户至少掌握了这两种按键的一种
```
(defcustom eaf-browser-caret-mode-keybinding
  '(
    ("/" . "caret_search_forward")
    ("?" . "caret_search_backward")
    ("q" . "caret_exit")
    ("v" . "caret_exit")
    ("C-q" . "caret_exit")
    ("j" . "caret_next_line")
    ("k" . "caret_previous_line")
    ("l" . "caret_next_character")
    ("h" . "caret_previous_character")
    ("w" . "caret_next_word")
    ("b" . "caret_previous_word")
    ("g" . "caret_to_bottom")
    ("G" . "caret_to_top")
    ("C-s" . "caret_search_forward")
    ("C-r" . "caret_search_backward")
    ("C-n" . "caret_next_line")
    ("C-p" . "caret_previous_line")
    ("C-f" . "caret_next_character")
    ("C-b" . "caret_previous_character")
    ("M-f" . "caret_next_word")
    ("M-b" . "caret_previous_word")
    ("C-." . "caret_clear_search")
    )
  "The keybinding of EAF Browser Caret Mode."
  :type 'cons)
```
eaf 动态绑定的秘密就在下面，
```
  ;; Copy default value in case user already has bindings there
  (setq-local emulation-mode-map-alists
              (copy-alist (default-value 'emulation-mode-map-alists)))
  ;; Construct map alist
  (setq-local eaf--buffer-map-alist (list (cons t eaf-mode-map)))
  ;; Eanble mode map and make it the first priority
  (add-to-ordered-list
   'emulation-mode-map-alists
   'eaf--buffer-map-alist
   'eaf--buffer-map-alist-order)
```

修改了 eaf-mode-map 不生效，是因为 eaf--buffer-map-alist 没有更新，需要执行
```
(setq eaf--buffer-map-alist (list (cons t eaf-mode-map)))
```



