### PR TITLE
Fix annotations

### DIFF
--- a/app/pdf-viewer/buffer.py
+++ b/app/pdf-viewer/buffer.py
@@ -243,6 +243,7 @@ class PdfViewerWidget(QWidget):
 
         # annot
         self.is_hover_annot = False
+        self.edited_page_annot = (None, None)
 
         # Init scroll attributes.
         self.scroll_step = 20
@@ -958,13 +959,15 @@ class PdfViewerWidget(QWidget):
                     self.get_focus_text.emit(self.buffer_id, annot.info["content"])
                 else:
                     self.buffer.message_to_emacs.emit("Cannot edit. Only support text annot type.")
+                self.edited_page_annot = (page, annot)
 
     def update_annot_text(self, annot_text):
-        page, annot = self.hover_annot()
+        page, annot = self.edited_page_annot
         if annot.parent:
             annot.setInfo(content=annot_text)
             annot.update()
         self.save_annot()
+        self.edited_annot = (None, None)
 
     def jump_to_page(self, page_num):
         self.update_vertical_offset(min(max(self.scale * (int(page_num) - 1) * self.page_height, 0), self.max_scroll_offset()))

--- a/app/pdf-viewer/buffer.py
+++ b/app/pdf-viewer/buffer.py
@@ -929,19 +929,28 @@ class PdfViewerWidget(QWidget):
             annots.append(annot)
             annot = annot.next
 
+        is_hover_annot = False
+        current_annot = None
         for annot in annots:
             if fitz.Point(ex, ey) in annot.rect:
-                self.is_hover_annot = True
-                annot.setOpacity(0.5)
+                # self.buffer.message_to_emacs.emit(annot.info["content"])
+                is_hover_annot = True
+                current_annot = annot
+                opacity = 0.5
                 self.buffer.message_to_emacs.emit("[d]Delete Annot [e]Edit Annot")
             else:
-                annot.setOpacity(1) # restore annot
-                self.is_hover_annot = False
-            annot.update()
+                opacity = 1.0
+            if opacity != annot.opacity:
+                annot.setOpacity(opacity)
+                annot.update()
 
-        self.page_cache_pixmap_dict.clear()
-        self.update()
-        return page, annot
+        # update only if changed
+        if is_hover_annot != self.is_hover_annot:
+            self.is_hover_annot = is_hover_annot
+            self.page_cache_pixmap_dict.clear()
+            self.update()
+
+        return page, current_annot
 
     def save_annot(self):
         self.document.saveIncr()

--- a/app/pdf-viewer/buffer.py
+++ b/app/pdf-viewer/buffer.py
@@ -955,11 +955,8 @@ class PdfViewerWidget(QWidget):
                 page.deleteAnnot(annot)
                 self.save_annot()
             if action == "edit":
-                if annot.type[0] == 0:
-                    self.get_focus_text.emit(self.buffer_id, annot.info["content"])
-                else:
-                    self.buffer.message_to_emacs.emit("Cannot edit. Only support text annot type.")
                 self.edited_page_annot = (page, annot)
+                self.get_focus_text.emit(self.buffer_id, annot.info["content"].replace("\r", "\n"))
 
     def update_annot_text(self, annot_text):
         page, annot = self.edited_page_annot

--- a/app/pdf-viewer/buffer.py
+++ b/app/pdf-viewer/buffer.py
@@ -947,7 +947,7 @@ class PdfViewerWidget(QWidget):
         # update only if changed
         if is_hover_annot != self.is_hover_annot:
             self.is_hover_annot = is_hover_annot
-            self.page_cache_pixmap_dict.clear()
+            del self.page_cache_pixmap_dict[page_index]
             self.update()
 
         return page, current_annot


### PR DESCRIPTION
This pull request fixes EAF/pdf-viewer slowness for pdf pages with many annotations; enables editing an annotation that is not the last one on the page; enables saving annotation text when the mouse pointer does not hover over the edited annotation; fixes Windows newlines in annotation text; and, enables annotation text for all annotation types.