### PR TITLE
Caret Browsing: Dark mode caret

### DIFF
--- a/core/browser.py
+++ b/core/browser.py
@@ -77,7 +77,7 @@ class BrowserView(QWebEngineView):
         self.clear_focus_js = self.read_js_content("clear_focus.js")
         self.select_input_text_js = self.read_js_content("select_input_text.js")
         self.dark_mode_js = self.read_js_content("dark_mode.js")
-        self.caret_browsing_js = self.read_js_content("caret_browsing.js")
+        self.caret_browsing_js_raw = self.read_js_content("caret_browsing.js")
         self.get_selection_text_js = self.read_js_content("get_selection_text.js")
         self.focus_input_js = self.read_js_content("focus_input.js")
 
@@ -617,6 +617,8 @@ class BrowserBuffer(Buffer):
         self.progressbar_height = 2
         self.light_mode_mask_color = QColor("#FFFFFF")
         self.dark_mode_mask_color = QColor("#242525")
+        self.caret_background_color = QColor(self.emacs_var_dict["eaf-emacs-theme-background-color"])
+        self.caret_foreground_color = QColor(self.emacs_var_dict["eaf-emacs-theme-foreground-color"])
 
         self.current_url = ""
         self.request_url = ""
@@ -795,7 +797,25 @@ class BrowserBuffer(Buffer):
             self.update()
         elif progress == 100 and self.draw_progressbar:
             self.init_auto_fill()
-            self.buffer_widget.eval_js(self.buffer_widget.caret_browsing_js)
+            if self.dark_mode_is_enable():
+                if self.emacs_var_dict["eaf-browser-dark-mode"] == "follow":
+                    self.caret_browsing_js = self.buffer_widget.caret_browsing_js_raw.replace("%1", "#"+ str(hex(self.caret_background_color.red()//16)).replace("0x","")+ \
+                                                                                                         str(hex(self.caret_background_color.green()//16)).replace("0x","")+ \
+                                                                                                         str(hex(self.caret_background_color.blue()//16)).replace("0x","")).replace("%2", "#"+ str(hex(self.caret_foreground_color.red()//16)).replace("0x","")+ \
+                                                                                                                                                                                               str(hex(self.caret_foreground_color.green()//16)).replace("0x","")+ \
+                                                                                                                                                                                               str(hex(self.caret_foreground_color.blue()//16)).replace("0x",""))
+                else:
+                    self.caret_browsing_js = self.buffer_widget.caret_browsing_js_raw.replace("%1", "#FFF").replace("%2", "#000")
+            else:
+                if self.emacs_var_dict["eaf-browser-dark-mode"] == "follow":
+                    self.caret_browsing_js = self.buffer_widget.caret_browsing_js_raw.replace("%1", "#"+ str(hex(self.caret_background_color.red()//16)).replace("0x","") + \
+                                                                                                         str(hex(self.caret_background_color.green()//16)).replace("0x","")+ \
+                                                                                                         str(hex(self.caret_background_color.blue()//16)).replace("0x","")).replace("%2", "#"+ str(hex(self.caret_foreground_color.red()//16)).replace("0x","")+ \
+                                                                                                                                                                                               str(hex(self.caret_foreground_color.green()//16)).replace("0x","")+ \
+                                                                                                                                                                                               str(hex(self.caret_foreground_color.blue()//16)).replace("0x",""))
+                else:
+                    self.caret_browsing_js = self.buffer_widget.caret_browsing_js_raw.replace("%1", "#000").replace("%2", "#FFF")
+            self.buffer_widget.eval_js(self.caret_browsing_js)
             self.eval_caret_js = True
             if self.emacs_var_dict["eaf-browser-enable-adblocker"] == "true":
                 self.buffer_widget.load_adblocker()

--- a/core/js/caret_browsing.js
+++ b/core/js/caret_browsing.js
@@ -556,9 +556,9 @@ CaretBrowsing.caretWidth = 0;
 
 CaretBrowsing.caretHeight = 0;
 
-CaretBrowsing.caretForeground = "#000";
+CaretBrowsing.caretForeground = "%2";
 
-CaretBrowsing.caretBackground = "#fff";
+CaretBrowsing.caretBackground = "%1";
 
 CaretBrowsing.isSelectionCollapsed = false;
 
@@ -669,7 +669,7 @@ CaretBrowsing.injectCaretStyles = function() {
         "  position: absolute;" +
         "  z-index: 2147483647;" +
         "  min-height: 10px;" +
-        "  background-color: #000;" +
+        "  background-color: %1;" +
         "}" +
         ".CaretBrowsing_AnimateCaret {" +
         "  position: absolute;" +
@@ -951,11 +951,8 @@ CaretBrowsing.updateCaretOrSelection =
         if (elem.constructor === Text) {
             elem = elem.parentElement;
         }
-        const style = window.getComputedStyle(elem);
-        const bg = axs.utils.getBgColor(style, elem);
-        const fg = axs.utils.getFgColor(style, elem, bg);
-        CaretBrowsing.caretBackground = axs.color.colorToString(bg);
-        CaretBrowsing.caretForeground = axs.color.colorToString(fg);
+        CaretBrowsing.caretBackground = "%1";
+        CaretBrowsing.caretForeground = "%2";
 
         if (scrollToSelection) {
             const rect = CaretBrowsing.getCursorRect(

--- a/core/js/dark_mode.js
+++ b/core/js/dark_mode.js
@@ -1576,7 +1576,7 @@
         return overridesList.map(function (_a) {
             var dataAttr = _a.dataAttr, customProp = _a.customProp, cssProp = _a.cssProp;
             return [
-                "[" + dataAttr + "] {",
+                "[" + dataAttr + ":not(.CaretBrowsing)] {",
                 "  " + cssProp + ": var(" + customProp + ") !important;",
                 '}',
             ].join('\n');


### PR DESCRIPTION
Exclude class `CaretBrowsing` from dark mode bgcolor inline style.

Optimize dark mode color algorithm of Caret Browsing cursor so that it can follow `eaf-browser-dark-mode` settings.

![image](https://user-images.githubusercontent.com/43995067/89268582-512d7600-d66b-11ea-98be-8d93457080ed.png)


Signed-off-by: Hollow Man <hollowman186@vip.qq.com>