### PR TITLE
PDF-viewer: Calculate overlaps when excluding images

### DIFF
--- a/app/pdf-viewer/buffer.py
+++ b/app/pdf-viewer/buffer.py
@@ -389,14 +389,15 @@ class PdfViewerWidget(QWidget):
                 if time%2 == 1 and time//2 > 0:
                     imagebboxlist.extend(newly_added_overlapbboxlist)
 
-            # remove duplicate to make it run faster
-            for item in set(imagebboxlist):
-                if imagebboxlist.count(item) % 2 == 0:
-                    while item in imagebboxlist:
-                        imagebboxlist.remove(item)
-                else:
-                    while imagebboxlist.count(item) > 1:
-                        imagebboxlist.remove(item)
+            if len(imagebboxlist) != len(set(imagebboxlist)):
+                # remove duplicate to make it run faster
+                for item in set(imagebboxlist):
+                    if imagebboxlist.count(item) % 2 == 0:
+                        while item in imagebboxlist:
+                            imagebboxlist.remove(item)
+                    else:
+                        while imagebboxlist.count(item) > 1:
+                            imagebboxlist.remove(item)
             for bbox in imagebboxlist:
                 pixmap.invertIRect(bbox * self.scale)
 


### PR DESCRIPTION
With this patch, now my [CV](https://github.com/HollowMan6/HollowMan6.github.io/tree/master/CV/CV-Songlin-Jiang-English.pdf) can be displayed correctly using PDF-Viewer under dark mode

Further optimize dark mode image excluding algorithms in PDF viewer in #308 by reinverting overlaps if pictures have overlaps.

| Previous | Current |
| :--------: | :--------: |
| <img src="https://user-images.githubusercontent.com/43995067/89279841-6eb60c00-d67a-11ea-8d71-6ae11fb0ad08.png" width="400"> |<img src="https://user-images.githubusercontent.com/43995067/89280057-afae2080-d67a-11ea-9140-2cd2227396ea.png" width="400">|

Complicated Cases:

3 layers' overlap :  [2.pdf](https://github.com/manateelazycat/emacs-application-framework/files/5022755/2.pdf)

![image](https://user-images.githubusercontent.com/43995067/89307928-3b887280-d6a4-11ea-923b-55372d6bcc37.png)

4 layers' overlap :  [3.pdf](https://github.com/manateelazycat/emacs-application-framework/files/5022763/3.pdf)

![image](https://user-images.githubusercontent.com/43995067/89308084-6e326b00-d6a4-11ea-89c0-bfdad8041901.png)

[4.pdf](https://github.com/manateelazycat/emacs-application-framework/files/5022772/4.pdf)

![image](https://user-images.githubusercontent.com/43995067/89308258-a174fa00-d6a4-11ea-8439-e18757269ef4.png)

Signed-off-by: Hollow Man <hollowman186@vip.qq.com>