### PR TITLE
Disable evil keybindings when evil enabled in eaf buffer.

### DIFF
--- a/eaf-evil.el
+++ b/eaf-evil.el
@@ -50,8 +50,8 @@
 
   (add-hook 'evil-normal-state-entry-hook
             (lambda ()
-              (define-key eaf-mode-map (kbd eaf-evil-leader-key) eaf-evil-leader-keymap)
               (when (derived-mode-p 'eaf-mode)
+                (define-key eaf-mode-map (kbd eaf-evil-leader-key) eaf-evil-leader-keymap)
                 (setq emulation-mode-map-alists
                       (delq 'evil-mode-map-alist emulation-mode-map-alists)))))
 

--- a/eaf-evil.el
+++ b/eaf-evil.el
@@ -37,67 +37,27 @@
 ;; the Free Software Foundation, Inc., 51 Franklin Street, Fifth
 ;; Floor, Boston, MA 02110-1301, USA.
 
-(defvar eaf-printable-character
-  (mapcar #'char-to-string (number-sequence ?! ?~))
-  "printable character")
+(defcustom eaf-evil-leader-key "C-SPC"
+  "Leader key trigger" )
 
-;; EAF evil Key Configuration
-(defun eaf-evil-lookup-key (key)
-  (or (lookup-key eaf-mode-map (kbd key))
-      (lookup-key (current-local-map) (kbd key))
-      ;; sequence key
-      (when (or (string-prefix-p "C-" key)
-                (string-prefix-p "M-" key))
-        (lookup-key (current-global-map) (kbd key)))
-      'eaf-send-key))
-
-
-(defun eaf-generate-normal-state-key-func (key)
-  (lambda () (interactive)
-    (call-interactively (eaf-evil-lookup-key key))))
-
-(defun eaf-evil-define-single-keys ()
-  (dolist (key (append  eaf-printable-character
-                        '("<escape>" "RET" "DEL" "TAB" "SPC" "<backtab>" "<home>" "<end>" "<left>" "<right>" "<up>" "<down>" "<prior>" "<next>" "<delete>" "<backspace>" "<return>")))
-    (evil-define-key* '(normal insert) eaf-mode-map* (kbd key)
-      (eaf-generate-normal-state-key-func key))))
-
-(defun eaf-evil-define-ctrl-keys ()
-  (dolist (key (seq-difference  eaf-printable-character
-                                (mapcar #'char-to-string "wWxXcChH[1234567890")))
-    (evil-define-key* '(normal insert) eaf-mode-map* (kbd (format "C-%s" key))
-      (eaf-generate-normal-state-key-func (format "C-%s" key)))))
-
-
-(defun eaf-evil-define-meta-keys ()
-  (dolist (key (seq-difference  eaf-printable-character
-                                (mapcar #'char-to-string "xX::1234567890")))
-    (evil-define-key* '(normal insert) eaf-mode-map* (kbd (format "M-%s" key))
-      (eaf-generate-normal-state-key-func (format "M-%s" key)))))
-
-(defun eaf-browser-focus-p ()
-  (eq (eaf-call "call_function" eaf--buffer-id "is_focus") t))
-
-(defun eaf-browser-focus-handler ()
-  (if (eaf-browser-focus-p)
-      (unless (evil-insert-state-p) (evil-insert-state))
-    (when (evil-insert-state-p) (evil-normal-state))))
+(defcustom eaf-evil-leader-keymap #'doom/leader
+  "Leader key bind"
+  :type 'keymap)
 
 (defun eaf-enable-evil-intergration ()
   "EAF evil intergration."
   (interactive)
-  (when (featurep 'evil)
-    (eaf-evil-define-single-keys)
-    (eaf-evil-define-ctrl-keys)
-    (eaf-evil-define-meta-keys)
-    (add-to-list 'evil-insert-state-modes 'eaf-edit-mode)
-    (eaf-bind-key clear_focus "<escape>" eaf-browser-keybinding)
-    (add-hook 'eaf-browser-hook (lambda () (add-hook 'post-command-hook #'eaf-browser-focus-handler nil t)))
-    ;; TODO: add 'eaf-terminal-hook
-    ;; (add-hook 'eaf-mode-hook (lambda () ()
-    ;;                            (when (string= "terminal" eaf--buffer-app-name)
-    ;;                                 (evil-emacs-state))))
-    ))
+
+  (add-hook 'evil-normal-state-entry-hook
+            (lambda ()
+              (define-key eaf-mode-map (kbd eaf-evil-leader-key) eaf-evil-leader-keymap)
+              (when (derived-mode-p 'eaf-mode)
+                (setq emulation-mode-map-alists
+                      (delq 'evil-mode-map-alist emulation-mode-map-alists)))))
+
+  (add-to-list 'evil-insert-state-modes 'eaf-edit-mode)
+
+  (eaf-bind-key clear_focus "<escape>" eaf-browser-keybinding))
 
 (with-eval-after-load "evil"
   (eaf-enable-evil-intergration))

--- a/eaf.el
+++ b/eaf.el
@@ -319,7 +319,9 @@ Try not to modify this alist directly.  Use `eaf-setq' to modify instead."
     ("C-y" . "caret_translate_text")
     ("C-q" . "caret_exit")
     ("c"   . "insert_or_caret_at_line")
-    ("M-c" . "caret_toggle_browsing"))
+    ("M-c" . "caret_toggle_browsing")
+    ("<escape>" . "caret_exit")
+    )
   "The keybinding of EAF Browser Caret Mode."
   :type 'cons)
 


### PR DESCRIPTION
----
# Disable evil keybindings when evil enabled in eaf buffer.
1. 以前实现的方式是把可打印的按键绑定到对应的 eaf 按键, 这几天通过学习 elisp keymaps 对 emacs 的 keymap 查询机制有了进一步的了解，发现只需要清空 ~emulation-mode-map-alists~ 里面的 ~evil-mode-map-alist~ 的按键，就能实现以前的效果。

# Exit caret mode when you type <escape> key.
2. 增加 \<escape> 按键退出 caret-mode, 更符合 vim 用户的习惯.