### PR TITLE
Fix focus issues when using browser

### DIFF
--- a/core/browser.py
+++ b/core/browser.py
@@ -665,6 +665,7 @@ class BrowserBuffer(Buffer):
             settings.setAttribute(QWebEngineSettings.FullScreenSupportEnabled, True)
             settings.setAttribute(QWebEngineSettings.PlaybackRequiresUserGesture, False)
             settings.setAttribute(QWebEngineSettings.DnsPrefetchEnabled, True)
+            settings.setAttribute(QWebEngineSettings.FocusOnNavigationEnabled, True)
         except Exception:
             pass
 


### PR DESCRIPTION
Fix [focus issues](https://github.com/manateelazycat/emacs-application-framework/pull/345#issuecomment-669994276) when selecting text, where the selection gets grey instead of blue:

 ![Screen Capture_select-area_20200806111435](https://user-images.githubusercontent.com/12422335/89549494-5f4bd580-d7d6-11ea-99b1-c71b4f31a3a4.png)

Signed-off-by: Hollow Man <hollowman186@vip.qq.com>