### PR TITLE
Browser: Support duplicating current page in new tab

### DIFF
--- a/app/browser/buffer.py
+++ b/app/browser/buffer.py
@@ -49,6 +49,7 @@ class AppBuffer(BrowserBuffer):
         self.buffer_widget.translate_selected_text.connect(self.translate_text)
 
         self.buffer_widget.open_url_in_new_tab.connect(self.open_url_in_new_tab)
+        self.buffer_widget.duplicate_page_in_new_tab.connect(self.duplicate_page_in_new_tab)
         self.buffer_widget.open_url_in_background_tab.connect(self.open_url_in_background_tab)
 
         self.buffer_widget.urlChanged.connect(self.set_adblocker)

--- a/core/browser.py
+++ b/core/browser.py
@@ -42,6 +42,7 @@ MOUSE_FORWARD_BUTTON = 16
 class BrowserView(QWebEngineView):
 
     open_url_in_new_tab = QtCore.pyqtSignal(str)
+    duplicate_page_in_new_tab = QtCore.pyqtSignal(str)
     open_url_in_background_tab = QtCore.pyqtSignal(str)
     translate_selected_text = QtCore.pyqtSignal(str)
     trigger_focus_event = QtCore.pyqtSignal(str)
@@ -1347,6 +1348,10 @@ class BrowserBuffer(Buffer):
                     self.message_to_emacs.emit("No page need recovery.")
         else:
             self.message_to_emacs.emit("No page need recovery.")
+
+    @interactive(insert_or_do=True)
+    def duplicate_page(self):
+        self.buffer_widget.duplicate_page_in_new_tab.emit(self.current_url)
 
     @interactive(insert_or_do=True)
     def open_browser(self):

--- a/core/buffer.py
+++ b/core/buffer.py
@@ -101,6 +101,7 @@ class Buffer(QGraphicsScene):
 
     update_buffer_details = QtCore.pyqtSignal(str, str, str)
     open_url_in_new_tab = QtCore.pyqtSignal(str)
+    duplicate_page_in_new_tab = QtCore.pyqtSignal(str) 
     open_url_in_background_tab = QtCore.pyqtSignal(str)
     translate_text = QtCore.pyqtSignal(str)
     input_message = QtCore.pyqtSignal(str, str, str, str, str)

--- a/eaf.el
+++ b/eaf.el
@@ -356,6 +356,7 @@ Try not to modify this alist directly.  Use `eaf-setq' to modify instead."
     ("M-v" . "scroll_down_page")
     ("M-<" . "scroll_to_begin")
     ("M->" . "scroll_to_bottom")
+    ("M-p" . "duplicate_page")
     ("M-t" . "new_blank_page")
     ("SPC" . "insert_or_scroll_up_page")
     ("J" . "insert_or_select_left_tab")
@@ -388,6 +389,7 @@ Try not to modify this alist directly.  Use `eaf-setq' to modify instead."
     ("y" . "insert_or_download_youtube_video")
     ("Y" . "insert_or_download_youtube_audio")
     ("p" . "insert_or_toggle_device")
+    ("P" . "insert_or_duplicate_page")
     ("1" . "insert_or_save_as_pdf")
     ("2" . "insert_or_save_as_single_file")
     ("v" . "insert_or_view_source")
@@ -1675,6 +1677,15 @@ In that way the corresponding function will be called to retrieve the HTML
   "Open EAF browser application given a URL and ARGS."
   (interactive "M[EAF/browser] URL: ")
   (eaf-open (eaf-wrap-url url) "browser" args))
+
+(dbus-register-signal
+ :session "com.lazycat.eaf" "/com/lazycat/eaf"
+ "com.lazycat.eaf" "duplicate_page_in_new_tab"
+ #'eaf-browser--duplicate-page-in-new-tab)
+
+(defun eaf-browser--duplicate-page-in-new-tab (url)
+  "Duplicate a new tab for the dedicated URL."
+  (eaf-open (eaf-wrap-url url) "browser" nil t))
 
 (defun eaf-is-valid-url (url)
   "Return the same URL if it is valid."

--- a/eaf.py
+++ b/eaf.py
@@ -177,6 +177,7 @@ class EAF(dbus.service.Object):
         app_buffer.update_buffer_details.connect(self.update_buffer_details)
         app_buffer.translate_text.connect(self.translate_text)
         app_buffer.open_url_in_new_tab.connect(self.open_url_in_new_tab)
+        app_buffer.duplicate_page_in_new_tab.connect(self.duplicate_page_in_new_tab)
         app_buffer.open_url_in_background_tab.connect(self.open_url_in_background_tab)
         app_buffer.goto_left_tab.connect(self.goto_left_tab)
         app_buffer.goto_right_tab.connect(self.goto_right_tab)
@@ -467,6 +468,10 @@ class EAF(dbus.service.Object):
 
     @dbus.service.signal(EAF_DBUS_NAME)
     def open_url_in_new_tab(self, url):
+        pass
+
+    @dbus.service.signal(EAF_DBUS_NAME)
+    def duplicate_page_in_new_tab(self, url):
         pass
 
     @dbus.service.signal(EAF_DBUS_NAME)


### PR DESCRIPTION
Using `M-p` or `P` to duplicate current page in new tab.

(This is the new task that appeared in the [To-do List](https://github.com/manateelazycat/emacs-application-framework/wiki/Todo-List) which I have just noticed.)

Signed-off-by: Hollow Man <hollowman@hollowman.ml>