### PR TITLE
fix(config_dir): add the trailing slash if it's not already there

### DIFF
--- a/eaf.py
+++ b/eaf.py
@@ -52,7 +52,7 @@ class EAF(dbus.service.Object):
         (emacs_width, emacs_height, proxy_host, proxy_port, proxy_type, config_dir, var_dict_string) = args
         emacs_width = int(emacs_width)
         emacs_height = int(emacs_height)
-        eaf_config_dir = os.path.expanduser(config_dir)
+        eaf_config_dir = os.path.join(os.path.expanduser(config_dir), '')
 
         self.buffer_dict = {}
         self.view_dict = {}


### PR DESCRIPTION
add the trailing slash if it's not already there

---

库里有些地方使用了 os.path.dirname 这个函数，如果 eaf-config-location 没有尾斜杠，路径错误(?)会造成 eaf 启动失败 (在系统日志和eaf日志中看不到异常信息)。

这个问题是从这开始引入的:
https://github.com/manateelazycat/emacs-application-framework/commit/b7bd683d9782176a0e65c484a6a6e7a4cae2d782?branch=b7bd683d9782176a0e65c484a6a6e7a4cae2d782&diff=unified#diff-4ac38a465cefc0d5e0d12cb95d4368e6R574
