### PR TITLE
improve pdf-viewer render quality

### DIFF
--- a/app/pdf-viewer/buffer.py
+++ b/app/pdf-viewer/buffer.py
@@ -516,7 +516,7 @@ class PdfViewerWidget(QWidget):
                 # Draw page image.
                 if self.read_mode == "fit_to_customize" and render_width >= self.rect().width():
                     render_x = max(min(render_x + self.horizontal_offset, 0), self.rect().width() - render_width) # limit the visiable area size
-                painter.drawPixmap(QRect(render_x, render_y, render_width, render_height), qpixmap)
+                painter.drawPixmap(QRect(render_x, render_y, qpixmap.width(), qpixmap.height()), qpixmap)
 
         # Clean unused pixmap cache that avoid use too much memory.
         self.clean_unused_page_cache_pixmap()


### PR DESCRIPTION
the pixmap and rectangle size should be the same, otherwise the pixmap will be scaled, leading to poor render quality. 
Find more information [here](https://doc.qt.io/qt-5/qpainter.html#drawPixmap-9). 