### PR TITLE
Force use xcb backend at wayland desktop session

### DIFF
--- a/eaf.el
+++ b/eaf.el
@@ -985,7 +985,9 @@ Return t or nil based on the result of the call."
                    (list eaf-proxy-host eaf-proxy-port eaf-proxy-type eaf-config-location)
                    (list (eaf-serialization-var-list))
                    ))
-        (gdb-args (list "-batch" "-ex" "run" "-ex" "bt" "--args" eaf-python-command)))
+        (gdb-args (list "-batch" "-ex" "run" "-ex" "bt" "--args" eaf-python-command))
+        (process-environment (cl-copy-list process-environment)))
+    (setenv "QT_QPA_PLATFORM" "xcb")
     (setq eaf-process
           (if eaf-enable-debug
               (apply #'start-process eaf-name eaf-name "gdb" (append gdb-args eaf-args))


### PR DESCRIPTION
Add QT_QPA_PLATFORM arg for eaf python process. Can use eaf on wayland desktop session environment. Like kde plasma-wayland.