### PR TITLE
require missing dependency: s.el

### DIFF
--- a/eaf.el
+++ b/eaf.el
@@ -88,6 +88,7 @@
 (require 'eaf-mindmap)
 (require 'eaf-interleave)
 (require 'json)
+(require 's)
 
 ;;; Code:
 


### PR DESCRIPTION
fix error: "last: Symbol’s function definition is void: s-split"