### PR TITLE
fix(mindmap): make new node in edit mode

### DIFF
--- a/app/mindmap/buffer.py
+++ b/app/mindmap/buffer.py
@@ -45,7 +45,11 @@ class AppBuffer(BrowserBuffer):
 
         self.cut_node_id = None
 
-        for method_name in ["add_sub_node", "add_brother_node", "remove_node", "remove_middle_node", "add_middle_node", "update_node_topic_inline"]:
+        edit_mode = "true" if self.emacs_var_dict["eaf-mindmap-edit-mode"] == "true" else "false"
+        for method_name in ["add_sub_node", "add_brother_node", "add_middle_node"]:
+            self.build_js_method(method_name, True, js_kwargs={"inline": edit_mode})
+
+        for method_name in ["remove_node", "remove_middle_node", "update_node_topic_inline"]:
             self.build_js_method(method_name, True)
 
         for method_name in ["zoom_in", "zoom_out", "zoom_reset",
@@ -86,9 +90,11 @@ class AppBuffer(BrowserBuffer):
 
         self.change_title(self.get_root_node_topic())
 
-    def build_js_method(self, method_name, auto_save=False):
+    def build_js_method(self, method_name, auto_save=False, js_kwargs=None):
+        js_kwargs = js_kwargs or {}
+        js_func_args = ", ".join('{}={}'.format(k, v) for k, v in js_kwargs.items())
         def _do ():
-            self.buffer_widget.eval_js("{}();".format(method_name))
+            self.buffer_widget.eval_js("{}({});".format(method_name, js_func_args))
 
             if auto_save:
                 self.save_file(False)

--- a/app/mindmap/index.html
+++ b/app/mindmap/index.html
@@ -60,7 +60,7 @@
           }
       }
 
-      function add_sub_node(){
+      function add_sub_node(inline=false){
           var selected_node = _jm.get_selected_node(); // as parent of new node
           if(!selected_node) {
               _jm.move_node(selected_id,'_first_');
@@ -69,6 +69,9 @@
           var nodeid = jsMind.util.uuid.newid();
           var node = _jm.add_node(selected_node, nodeid, 'Topic');
           _jm.select_node(node);
+          if (inline) {
+              _jm.begin_edit(node);
+          }
       }
 
       function add_texted_sub_node(text){
@@ -81,7 +84,7 @@
           _jm.add_node(selected_node, nodeid, text);
       }
 
-      function add_brother_node(){
+      function add_brother_node(inline=false){
           var selected_node = _jm.get_selected_node(); // as parent of new node
           if(!selected_node) {
               _jm.move_node(selected_id,'_first_');
@@ -92,6 +95,9 @@
               var nodeid = jsMind.util.uuid.newid();
               var node = _jm.insert_node_after(selected_node, nodeid, 'Topic');
               _jm.select_node(node);
+              if (inline) {
+                  _jm.begin_edit(node);
+              }
           }
       }
 
@@ -291,12 +297,12 @@
           }
       }
 
-      function add_middle_node() {
+      function add_middle_node(inline=false) {
           var selected_node = _jm.get_selected_node(); // as parent of new node
           if(!!selected_node) {
               var topic = selected_node.topic;
 
-              add_brother_node();
+              add_brother_node(inline=false);
 
               var brother_node = _jm.get_selected_node();
               _jm.update_node(brother_node.id, topic);
@@ -305,6 +311,9 @@
               _jm.move_node(selected_node, selected_node.id, brother_node.id, brother_node.direction);
 
               _jm.select_node(selected_node);
+              if (inline) {
+                  _jm.begin_edit(selected_node);
+              }
           }
       }
 

--- a/eaf.el
+++ b/eaf.el
@@ -283,6 +283,7 @@ It must defined at `eaf-browser-search-engines'."
     (eaf-terminal-font-family . "")
     (eaf-mindmap-dark-mode . "follow")
     (eaf-mindmap-save-path . "~/Documents")
+    (eaf-mindmap-edit-mode . "false")
     (eaf-marker-letters . "ASDFHJKLWEOPCNM")
     (eaf-emacs-theme-mode . "")
     (eaf-emacs-theme-background-color . "")


### PR DESCRIPTION
Before, the *RET* key is send directly to jsmind, and *handle_addbrother* in jsmind is called, not our *add_brother_node* function,
which make *add brother* correct, but *add sub*, *add middle* is not.
Now we make *RET*, *TAB*, *i* call our functions and add *begin_edit* in our functions.