### PR TITLE
fix(mindmap): fix inline always false

### DIFF
--- a/app/mindmap/index.html
+++ b/app/mindmap/index.html
@@ -302,7 +302,7 @@
           if(!!selected_node) {
               var topic = selected_node.topic;
 
-              add_brother_node(inline=false);
+              add_brother_node(false);
 
               var brother_node = _jm.get_selected_node();
               _jm.update_node(brother_node.id, topic);


### PR DESCRIPTION
Fix #425 .
```add_brother_node(inline=false)``` shadow the parameter *inline*, make it always false.
sorry for the pool test.