### PR TITLE
fix(mermaid): failed to load mermaid.js

### DIFF
--- a/app/mermaid/buffer.py
+++ b/app/mermaid/buffer.py
@@ -61,4 +61,4 @@ class AppBuffer(BrowserBuffer):
     def render(self):
         with open(self.url, "r") as f:
             html = markdown.markdown(f.read(), extensions=['app.mermaid.md_mermaid'])
-            self.buffer_widget.setHtml(html)
+            self.buffer_widget.setHtml(html, QUrl("file://"))


### PR DESCRIPTION
mermaid.js failed to load cause net::ERR_UNKNOWN_URL_SCHEME, see [QTBUG-55902](https://bugreports.qt.io/browse/QTBUG-55902).
![image](https://user-images.githubusercontent.com/2212586/97261729-683ec700-185a-11eb-9be9-76c997956bbe.png)
I'm not sure do we need to check the QT version, and set different *baseUrl* for *setHtml*.