### PR TITLE
pdf-viewer: auto detect file changed

### DIFF
--- a/eaf.el
+++ b/eaf.el
@@ -462,7 +462,6 @@ Try not to modify this alist directly.  Use `eaf-setq' to modify instead."
     ("i" . "toggle_inverted_mode")
     ("m" . "toggle_mark_link")
     ("f" . "jump_to_link")
-    ("r" . "refresh_file")
     ("M-w" . "copy_select")
     ("C-s" . "search_text_forward")
     ("C-r" . "search_text_backward")


### PR DESCRIPTION
``` python
import sys
import fitz

def mark_word(page, text):
    """Underline each word that contains 'text'.
    """
    found = 0
    wlist = page.getTextWords()        # make the word list
    for w in wlist:                    # scan through all words on page
        if text in w[4]:               # w[4] is the word's string
            found += 1                 # count
            r = fitz.Rect(w[:4])       # make rect from word bbox
            page.addUnderlineAnnot(r)  # underline
    return found

fname = sys.argv[1]                    # filename
text = sys.argv[2]                     # search string
doc = fitz.open(fname)

print("underlining words containing '%s' in document '%s'" % (text, doc.name))

new_doc = True                        # indicator if anything found at all

for page in doc:                       # scan through the pages
    found = mark_word(page, text)      # mark the page's words
    if found:                          # if anything found ...
        new_doc = True
        print("found '%s' %i times on page %i" % (text, found, page.number + 1))

if new_doc:
    doc.save("marked-" + doc.name)
```
test file : python test.py your.pdf you_want_to_mark_word
will save a marked-xxx pdf file and mark the specified word.