### PR TITLE
pdf-viewer: Opimize toggle dark mode logic for #453

### DIFF
--- a/eaf.el
+++ b/eaf.el
@@ -278,6 +278,7 @@ It must defined at `eaf-browser-search-engines'."
     (eaf-browser-chrome-history-file . "~/.config/google-chrome/Default/History")
     (eaf-pdf-dark-mode . "follow")
     (eaf-pdf-default-zoom . "1.0")
+    (eaf-pdf-dark-exclude-image . "true")
     (eaf-terminal-dark-mode . "follow")
     (eaf-terminal-font-size . "13")
     (eaf-terminal-font-family . "")


### PR DESCRIPTION
Adopted alternative solution in #453 by @Jdogzz 

Use `i` to toggle among `dark mode excluding images` -> `dark mode including images` -> `normal mode` -> ...

In addition, you can configure the emacs var dict to change the default behavior. If emacs var dict `eaf-pdf-dark-exclude-image` is true, the default dark mode will exclude images, otherwise it will include images.

Signed-off-by: Hollow Man <hollowman@hollowman.ml>