### PR TITLE
fix(jupyter): focus input when startup

### DIFF
--- a/app/jupyter/buffer.py
+++ b/app/jupyter/buffer.py
@@ -20,6 +20,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import json
+from PyQt5.QtCore import QTimer, QEvent, Qt
+from PyQt5.QtGui import QFocusEvent
+from PyQt5.QtWidgets import QApplication
 from qtconsole import styles
 from qtconsole.rich_jupyter_widget import RichJupyterWidget
 from qtconsole.manager import QtKernelManager
@@ -39,7 +42,13 @@ class AppBuffer(Buffer):
 
         self.add_widget(EafJupyterWidget(emacs_var_dict, self.kernel, font_size=font_size, font_family=font_family))
 
+        QTimer.singleShot(500, self.focus_widget)
+
         self.build_all_methods(self.buffer_widget)
+
+    def focus_widget(self):
+        event = QFocusEvent(QEvent.FocusIn, Qt.MouseFocusReason)
+        QApplication.sendEvent(self.buffer_widget.focusProxy(), event)
 
     def get_key_event_widgets(self):
         ''' Send key event to RichJupyterWidget's focusProxy widget.'''


### PR DESCRIPTION
启动后，如果不聚焦输入框，进行M-b, C-k等操作时，光标消失不见，必须要用鼠标点击一下才行，比较烦人。