### PR TITLE
eaf.el: test whether default-directory exists

### DIFF
--- a/eaf.el
+++ b/eaf.el
@@ -2075,7 +2075,8 @@ If ALWAYS-NEW is non-nil, always open a new terminal for the dedicated DIR."
 
 (defun eaf--non-remote-default-directory ()
   "Return `default-directory' itself if is not part of remote, otherwise return $HOME."
-  (if (file-remote-p default-directory)
+  (if (or (file-remote-p default-directory)
+          (not (file-exists-p default-directory)))
       (getenv "HOME")
     default-directory))
 


### PR DESCRIPTION
when ssh to remote machine, cd will change default-directory to dir in remote machine which may not exist in host machine.