### PR TITLE
terminal: trim preceding spaces of title

### DIFF
--- a/app/terminal/index.html
+++ b/app/terminal/index.html
@@ -166,7 +166,7 @@
           var re = /:([^\x07].*?)\x07/g;
           arr = re.exec(msg.data)
           if(arr) {
-              title = arr[1];
+              title = arr[1].trimLeft();
               executing_command = ""
           }
       }


### PR DESCRIPTION
if there are spaces between *:* and *\w* of $PS1, the terminal title will start with spaces, then the terminal buffer will not visible in emacs buffer list, and also you cannot select the buffer.