### PR TITLE
Add dnf (Fedora) support to install.sh

### DIFF
--- a/install-eaf.sh
+++ b/install-eaf.sh
@@ -15,6 +15,14 @@ if apt-get -v &> /dev/null; then
     sudo apt-get install python3-pyqt5 python3-sip python3-pyqt5.qtwebengine \
          python3-qrcode python3-feedparser python3-dbus python3-pyinotify \
          python3-markdown python3-qtconsole python3-pygit2
+         
+elif dnf &> /dev/null; then
+        sudo dnf install git nodejs aria2 libreoffice wmctrl xdotool
+        sudo dnf install glib2-devel dbus-devel
+
+        sudo dnf install python3-pyqt5-sip pyqtwebengine-devel python3-qrcode \
+             python3-feedparser python3-dbus  python3-inotify python3-markdown \
+             python3-qtconsole python3-pygit2
 
 elif type pacman &> /dev/null; then
     sudo pacman -Sy --needed "${ARCH_PACKAGES[@]}"


### PR DESCRIPTION
I guess these must be all packages required for Fedora.
Only I am not completely sure about the equivalents for libdbus-1-3 and python-pyqt5, but I guess they are covered.
(Maybe it could be mentioned in the README that feedback for install.sh in Fedora is welcome. The comment can be removed when it is clear that all is fine)