### PR TITLE
Fix headers and eval eaf-enable-evil-intergration after eaf instead of evil

### DIFF
--- a/eaf-evil.el
+++ b/eaf-evil.el
@@ -60,7 +60,7 @@
 
   (eaf-bind-key clear_focus "<escape>" eaf-browser-keybinding))
 
-(with-eval-after-load "evil"
+(with-eval-after-load "eaf"
   (eaf-enable-evil-intergration))
 
 (provide 'eaf-evil)

--- a/eaf-evil.el
+++ b/eaf-evil.el
@@ -1,4 +1,4 @@
-;; eaf-evil.el --- Emacs application framework  -*- lexical-binding: t; -*-
+;;; eaf-evil.el --- Emacs application framework  -*- lexical-binding: t; -*-
 
 ;; Filename: eaf-evil.el
 ;; Description: Emacs application framework

--- a/eaf-evil.el
+++ b/eaf-evil.el
@@ -44,6 +44,7 @@
   "Leader key bind"
   :type 'keymap)
 
+;;;###autoload
 (defun eaf-enable-evil-intergration ()
   "EAF evil intergration."
   (interactive)

--- a/eaf-org.el
+++ b/eaf-org.el
@@ -1,4 +1,4 @@
-;; eaf-org.el --- Emacs application framework  -*- lexical-binding: t; -*-
+;;; eaf-org.el --- Emacs application framework  -*- lexical-binding: t; -*-
 
 ;; Filename: eaf-org.el
 ;; Description: Emacs application framework

--- a/eaf.el
+++ b/eaf.el
@@ -1,4 +1,4 @@
-;; eaf.el --- Emacs application framework  -*- lexical-binding: t; -*-
+;;; eaf.el --- Emacs application framework  -*- lexical-binding: t; -*-
 
 ;; Filename: eaf.el
 ;; Description: Emacs application framework


### PR DESCRIPTION
I am trying to create a layer for Spacemacs. However, the package would not install using a qualpa recipe because the headers had only 2 `;`'s instead of 3, ad [described here](https://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Headers.html).

Also I tried to load `eaf-evil.el` :after `eaf`. However, with the `with-eval-after-load evil`, it would not load because clear_focus was not yet available. Changing it to ``with-eval-after-load eaf` fixed it.