### PR TITLE
Add Dockerfile.CN, facilitate Chinese to try eaf

### DIFF
--- a/docker/Dockerfile.CN
+++ b/docker/Dockerfile.CN
@@ -1,0 +1,34 @@
+FROM archlinux/archlinux
+
+RUN sed -i '1i Server = https://mirrors.tuna.tsinghua.edu.cn/archlinux/$repo/os/$arch' /etc/pacman.d/mirrorlist && \
+    sed -i '2i Server = https://mirrors.ustc.edu.cn/archlinux/$repo/os/$arch' /etc/pacman.d/mirrorlist && \
+    pacman -Syyu --noconfirm && \
+    pacman -S --needed --noconfirm sudo git emacs python-pip wqy-microhei wqy-zenhei && \
+    pacman -S --needed --noconfirm python-pyqt5 python-pyqt5-sip python-dbus python-pyqtwebengine wmctrl && \
+    pacman -S --needed --noconfirm python-qrcode && \
+    yes|pacman -Scc
+
+RUN pip install -i https://pypi.tuna.tsinghua.edu.cn/simple pip -U && \
+    pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple
+
+RUN pip install PyMuPDF grip && rm -rf /root/.cache
+
+RUN git clone --depth=1 https://gitee.com/emacs-hub/emacs-application-framework.git  && \
+    git clone --depth=1 https://github.com/magnars/s.el.git
+
+ARG _UID="1000"
+ARG _USER="eaf"
+RUN useradd --uid ${_UID}  -ms /bin/bash ${_USER}
+RUN echo "${_USER}     ALL=NOPASSWD: ALL" >> /etc/sudoers
+
+COPY docker-init.sh tmp/lib-scripts/
+RUN chmod +x /tmp/lib-scripts/docker-init.sh
+RUN chown ${_USER}:root /tmp/lib-scripts/docker-init.sh
+
+ENV LANG=zh_CN.UTF-8
+
+USER ${_USER}
+WORKDIR /home/${_USER}
+
+ENTRYPOINT [ "/tmp/lib-scripts/docker-init.sh" ]
+CMD [ "emacs", "-L", "/emacs-application-framework", "-L", "/s.el", "--eval", "(require 'eaf)" ]

--- a/docker/docker-init.sh
+++ b/docker/docker-init.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+if [ -z "$DBUS_SESSION_BUS_ADDRESS" ]; then
+    eval "$(dbus-launch)"
+    export DBUS_SESSION_BUS_ADDRESS
+fi
+
+exec "$@"


### PR DESCRIPTION
由于 eaf 更新有一段时间了，以前的 Dockerfile 构建使用还是有问题，另外中国内地用户构建的网速堪忧，故做了一些调整优化。
1. 尽量使用国内源
2. 基础镜像 archlinux/base 不推荐使用，替换为新的 archlinux/archlinux。具体见 https://hub.docker.com/r/archlinux/base
3. 只安装了一些主要依赖

个人测试平台：Win10 + WSL2 + Docker Desktop + MobaXterm

使用方法：
```shell
cd emacs-application-framework/docker

docker build -t eaf -f Dockerfile.CN .

xhost +
docker run --rm -it --network host -e DISPLAY -v /tmp/.X11-unix/:/tmp/.X11-unix -v ~/.Xauthority:/home/eaf/.Xauthority eaf
# mount the Emacs configuration into the container
docker run --rm -it --network host -e DISPLAY -v /tmp/.X11-unix/:/tmp/.X11-unix -v ~/.Xauthority:/home/eaf/.Xauthority -v ~/.emacs.d:/home/eaf/.emacs.d eaf
```

朋友们帮着测试下，看看效果。