### PR TITLE
Two small additions to support Spacemacs layer (quelpa installation)

### DIFF
--- a/core/browser.py
+++ b/core/browser.py
@@ -421,6 +421,7 @@ Otherwise, scroll page up.
         ''' Refresh the page.'''
         self.reload()
 
+    @interactive(insert_or_do=True)
     def copy_text(self):
         ''' Copy selected text.'''
         self.triggerPageAction(self.web_page.Copy)

--- a/eaf-evil.el
+++ b/eaf-evil.el
@@ -64,3 +64,9 @@
   (eaf-enable-evil-intergration))
 
 (provide 'eaf-evil)
+
+; don't use-package byte-compile to suppress clear_focus error
+; https://github.com/melpa/melpa/issues/1817#issuecomment-47467282
+;; Local Variables:
+;; no-byte-compile: t
+;; End:


### PR DESCRIPTION
Thanks to your help in #498 and #500, the Spacemacs layer is working as I like now. However, for it to work it needs these two small additions. I hope you can add this (so I don't need a separate fork)
1. create an `insert_or_copy command`, so that we can copy text by pressing `y`
2. Add a file local variable to prevent use-package from byte-compiling `eaf-evil.el` in order to suppress undefined variable error after byte-compilation (see https://github.com/melpa/melpa/issues/1817#issuecomment-47467282)

I have mentioned the error in the second point in #497, where I thought it was fixed by evaluating `eaf-enable-evil-intergration` after `eaf` instead of after `evil`. But now I find this was not a fix (anyway maybe this function should evaluate after `evil` and `eaf`,you have a clear idea about this? For now it works fine here).

Also you might be interested to add a simple command `install-eaf-dependencies` to run the install.sh script. Otherwise I will add it to the layer anyway. For that of course you need to add `-y` flags to the apt, dnf command, and equivalent flag for pacman, in the install.sh script.

As long as the layer is not official, it can be found at https://github.com/dalanicolai/eaf-layer