### PR TITLE
Do not ask for confirmation for apt and dnf commands in install-eaf

### DIFF
--- a/install-eaf.sh
+++ b/install-eaf.sh
@@ -7,20 +7,20 @@ ARCH_PACKAGES+=(python-pyqt5 python-pyqt5-sip python-pyqtwebengine python-qrcode
 ARCH_PACKAGES+=(python-dbus python-pyinotify python-markdown python-qtconsole)
 
 # System dependencies
-if apt-get -v &> /dev/null; then
-    sudo apt-get install git nodejs aria2 libreoffice wmctrl xdotool
-    sudo apt-get install libglib2.0-dev libdbus-1-3 libdbus-1-dev
+if apt -v &> /dev/null; then
+    sudo apt -y install git nodejs aria2 libreoffice wmctrl xdotool
+    sudo apt -y install libglib2.0-dev libdbus-1-3 libdbus-1-dev
     # Missing in Ubuntu: filebrowser-bin
 
-    sudo apt-get install python3-pyqt5 python3-sip python3-pyqt5.qtwebengine \
+    sudo apt -y install python3-pyqt5 python3-sip python3-pyqt5.qtwebengine \
          python3-qrcode python3-feedparser python3-dbus python3-pyinotify \
          python3-markdown python3-qtconsole python3-pygit2
          
 elif dnf &> /dev/null; then
-        sudo dnf install git nodejs aria2 libreoffice wmctrl xdotool
-        sudo dnf install glib2-devel dbus-devel
+        sudo dnf -y install git nodejs aria2 libreoffice wmctrl xdotool
+        sudo dnf -y install glib2-devel dbus-devel
 
-        sudo dnf install python3-pyqt5-sip pyqtwebengine-devel python3-qrcode \
+        sudo dnf -y install python3-pyqt5-sip pyqtwebengine-devel python3-qrcode \
              python3-feedparser python3-dbus  python3-inotify python3-markdown \
              python3-qtconsole python3-pygit2
 


### PR DESCRIPTION
For the Spacemacs EAF layer I have created an `install-eaf-dependencies` command (see [here](https://github.com/syl20bnr/spacemacs/blob/077b8ea07cac2917a69db3cc84601573e54710a5/layers/%2Btools/eaf/funcs.el)). However, I have created the command such that it requires automatic confirmation. This should be safe for the apt and dnf package managers. For arch, I read that maybe the option --no-confirm, would do it safely, but I can not test that. So I have only added it for the apt and dnf commands.
I hope you agree to merge it, because it would be very nice for the layer.