### PR TITLE
Add eaf-install-dependencies command and add quelpa recipe to doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,15 @@ EAF is an extensible framework, one can develop any Qt5 application and integrat
 ```Bash
 git clone https://github.com/manateelazycat/emacs-application-framework.git --depth=1 ~/.emacs.d/site-lisp/emacs-application-framework/
 ```
+or you can use a [Quelpa recipe](https://github.com/quelpa/quelpa)
+```Emacs-lisp
+(quelpa '(eaf (:fetcher github
+               :repo  "manateelazycat/emacs-application-framework"
+               :files ("*"))))
+```
 
-2. Install EAF dependencies, an explaination of each dependency can be found in [Dependency List](#dependency-list).
+2. Install EAF dependencies. An explanation of each dependency can be found in [Dependency List](#dependency-list).
+On Ubuntu or Fedora based distributions run `M-x install-eaf-dependencies`. On Arch bases distributions, `cd` to the emacs-application-framework directory and run install-eaf.sh: 
 
 ```Bash
 cd emacs-application-framework

--- a/eaf.el
+++ b/eaf.el
@@ -80,6 +80,12 @@
 
 (add-subdirs-to-load-path (expand-file-name "app" (file-name-directory (locate-library "eaf"))))
 
+(defun install-eaf-dependencies ()
+  (interactive)
+  (let ((default-directory "/sudo::")
+        (eaf-dir (file-name-directory (locate-library "eaf"))))
+    (shell-command (concat eaf-dir "install-eaf.sh" "&"))))
+
 (require 'dbus)
 (require 'subr-x)
 (require 'map)


### PR DESCRIPTION
As installing via Quelpa works fine on Spacemacs, I have added an example Quelpa recipe to the documentation. I think, like in Spacemacs, also in vanilla Emacs Quelpa packages can be managed/updated via the Emacs package-manager.