### PR TITLE
fixed define-obsolete-function-alias in emacs 28

### DIFF
--- a/eaf.el
+++ b/eaf.el
@@ -1966,7 +1966,7 @@ choose a search engine defined in `eaf-browser-search-engines'"
     (eaf-open search-url "browser")))
 
 ;;;###autoload
-(define-obsolete-function-alias 'eaf-open-url #'eaf-open-browser)
+(define-obsolete-function-alias 'eaf-open-url #'eaf-open-browser "20191224")
 
 ;;;###autoload
 (defun eaf-open-demo ()
@@ -2140,7 +2140,7 @@ When called interactively, URL accepts a file that can be opened by EAF."
       (setq input-string current-symbol))
     (eaf-open input-string "airshare")))
 
-(define-obsolete-function-alias 'eaf-file-transfer-airshare #'eaf-open-airshare)
+(define-obsolete-function-alias 'eaf-file-transfer-airshare #'eaf-open-airshare "20191224")
 
 (defun eaf-file-sender-qrcode (file)
   "Open EAF File Sender application.


### PR DESCRIPTION
The 'when' argument of `make-obsolete` and related functions is
mandatory since https://emba.gnu.org/emacs/emacs/-/commit/32c6732d16385f242b1109517f25e9aefd6caa5c

> The use of those functions without a 'when' argument was marked
obsolete back in Emacs-23.1.  The affected functions are:
make-obsolete, define-obsolete-function-alias, make-obsolete-variable,
define-obsolete-variable-alias.
