### PR TITLE
Create insert_or_dark_mode command (i.e. add decorator)

### DIFF
--- a/core/browser.py
+++ b/core/browser.py
@@ -577,7 +577,7 @@ Otherwise, scroll page up.
         ''' Clear the focus.'''
         self.eval_js(self.clear_focus_js)
 
-    @interactive()
+    @interactive(insert_or_do=True)
     def dark_mode(self):
         ''' Dark mode support.'''
         self.eval_js(self.dark_mode_js)


### PR DESCRIPTION
This is necessary to activate dark_mode (without restarting eaf-process) from browser.

I could not find a way to deactivate dark-mode without restarting the eaf-process. Is there an easy way? (Otherwise I already have a function to do it, that requires restarting the eaf-process)