### PR TITLE
Improve pdf scrolling

### DIFF
--- a/app/pdf-viewer/buffer.py
+++ b/app/pdf-viewer/buffer.py
@@ -284,6 +284,8 @@ class PdfViewerWidget(QWidget):
         self.scroll_offset = 0
         self.scroll_ratio = 0.05
         self.scroll_wheel_lasttime = time.time()
+        if self.emacs_var_dict["eaf-pdf-scroll-ratio"] != "0.05":
+            self.scroll_ratio = float(self.emacs_var_dict["eaf-pdf-scroll-ratio"])
 
         # Default presentation mode
         self.presentation_mode = False

--- a/eaf.el
+++ b/eaf.el
@@ -279,6 +279,7 @@ It must defined at `eaf-browser-search-engines'."
     (eaf-pdf-dark-mode . "follow")
     (eaf-pdf-default-zoom . "1.0")
     (eaf-pdf-dark-exclude-image . "true")
+    (eaf-pdf-scroll-ratio . "0.05")
     (eaf-terminal-dark-mode . "follow")
     (eaf-terminal-font-size . "13")
     (eaf-terminal-font-family . "")


### PR DESCRIPTION
1) continue mode, fixed pixel scrolling
2) presentation mode, page scrolling

---
原来的算法，位移量与 scale 正相关，缩放比例小或大会造成位移忽慢忽快奇怪的用户体验

改进 pdf 滚动的算法，提供一个可修改的变量 `eaf-pdf-scroll-ratio`

新的算法滚动时，位移量只与当前 pdf 模式、窗口高度、`eaf-pdf-scroll-ratio` 这个变量相关，位移逻辑近似模拟其它外部 pdf 工具

continue 模式下，默认位移量 窗口高度 * eaf-pdf-scroll-ratio
presentation 模式下，默认按页进行滚动