### PR TITLE
Add package s to the sample configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ or, if you use [use-package](https://github.com/jwiegley/use-package), you can u
   (use-package epc :defer t)
   (use-package ctable :defer t)
   (use-package deferred :defer t)
+  (use-package s :defer t :ensure t)
   :custom
   (eaf-browser-continue-where-left-off t)
   :config

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -114,6 +114,7 @@ node ./install-eaf-win32.js
   (use-package epc :defer t)
   (use-package ctable :defer t)
   (use-package deferred :defer t)
+  (use-package s :defer t :ensure t)
   :custom
   (eaf-browser-continue-where-left-off t)
   :config


### PR DESCRIPTION
If a user try eaf with the sample configuration in a fresh-install emacs, he will fail with error. He has to install package s to proceed. So package s should be added to the sample configuration.

> (use-package s :defer t :ensure t)