### PR TITLE
Add the support for calling eaf on Windows from Emacs on WSL 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Packages listed as **Core** are mandatory for EAF to work, whereas other package
 | python-pyqt5, python-pyqt5-sip | Core                                 | Essential GUI library                             |
 | python-pyqtwebengine           | Core                                 | Chromium based web rendering engine               |
 | wmctrl, xdotool                | Core                                 | Activate Emacs window input focus                 |
+| pygetwindow                    | Core                                 | Activate Emacs window input focus on WSL from Windows |
 | nodejs                         | Core                                 | Installs dependencies, and for app communications |
 | python-pymupdf                 | PDF Viewer                           | PDF rendering engine                              |
 | python-qrcode                  | File Sender, File Receiver, Airshare | Render QR code pointing to local files            |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -130,6 +130,7 @@ node ./install-eaf-win32.js
 | python-pyqt5, python-pyqt5-sip | 核心                         | GUI图形库                    |
 | python-pyqtwebengine           | 核心                         | 基于Chromium的浏览器引擎     |
 | wmctrl, xdotool                | 核心                         | 激活Emacs窗口输入焦点        |
+| pygetwindow                    | 核心                         | 从Windows中eaf激活WSL中Emacs窗口输入焦点 |
 | nodejs                         | 核心                         | 下载依赖与应用交互           |
 | python-pymupdf                 | PDF阅读器                    | 解析PDF文件                  |
 | python-qrcode                  | 文件上传，文件下载，文字传输 | 根据文件信息生成二维码       |

--- a/core/browser.py
+++ b/core/browser.py
@@ -34,6 +34,7 @@ import re
 import base64
 from functools import partial
 import sqlite3
+import platform
 
 
 MOUSE_BACK_BUTTON = 8
@@ -315,14 +316,20 @@ class BrowserView(QWebEngineView):
     def open_url(self, url):
         ''' Configure current url.'''
         self.setUrl(QUrl(url))
+        if platform.system() == "Windows":
+            self.buffer.eval_in_emacs.emit('eaf-activate-emacs-window', [])
 
     def open_url_new_buffer(self, url):
         ''' Open url in a new tab.'''
         self.open_url_in_new_tab.emit(url)
+        if platform.system() == "Windows":
+            self.buffer.eval_in_emacs.emit('eaf-activate-emacs-window', [])
 
     def open_url_background_buffer(self, url):
         ''' Open url in background tab.'''
         self.open_url_in_background_tab.emit(url)
+        if platform.system() == "Windows":
+            self.buffer.eval_in_emacs.emit('eaf-activate-emacs-window', [])
 
     @interactive(insert_or_do=True)
     def zoom_in(self):

--- a/core/view.py
+++ b/core/view.py
@@ -24,6 +24,7 @@ from PyQt5.QtCore import Qt, QEvent, QPoint
 from PyQt5.QtGui import QPainter, QWindow, QBrush, QColor
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QGraphicsView, QFrame
 import os
+import platform
 
 class View(QWidget):
 
@@ -124,6 +125,8 @@ class View(QWidget):
     def showEvent(self, event):
         # NOTE: we must reparent after widget show, otherwise reparent operation maybe failed.
         self.reparent()
+        if platform.system() == "Windows":
+            self.buffer.eval_in_emacs.emit('eaf-activate-emacs-window', [])
 
         # Make graphics view at left-top corner after show.
         self.graphics_view.verticalScrollBar().setValue(0)

--- a/eaf.py
+++ b/eaf.py
@@ -41,6 +41,8 @@ import platform
 import socket
 import subprocess
 import threading
+if platform.system() == "Windows":
+    import pygetwindow as gw
 
 class EAF(object):
     def __init__(self, args):
@@ -405,6 +407,15 @@ class EAF(object):
                 traceback.print_exc()
                 self.message_to_emacs("Cannot call function: " + function_name)
                 return ""
+
+    def get_emacs_xid(self):
+        if platform.system() == "Windows":
+            return gw.getActiveWindow()._hWnd
+
+    def activate_emacs_wsl_window(self, frame_title):
+        if platform.system() == "Windows":
+            w = gw.getWindowsWithTitle(frame_title)
+            w[0].activate()
 
     @PostGui()
     def action_quit(self, buffer_id):

--- a/install-eaf-win32.js
+++ b/install-eaf-win32.js
@@ -30,7 +30,8 @@ const pythonDeps = [
     "qrcode",
     "markdown",
     "epc",
-    "retrying"
+    "retrying",
+    "pygetwindow"
 ];
 
 function installPythonDep() {


### PR DESCRIPTION
我实现了在emacs-china上面提到的[在wsl下面调用windows下eaf的想法](https://emacs-china.org/t/emacs-linux-windows/6199/1257)。

请各位指教。

目前使用起来还存在失焦的问题。主要体现在浏览器上面。pdf阅读器等app可以自动获取焦点。主要有两个问题：1. 浏览器刚打开的时候需要用alt-tab为emacs获取焦点；2. 打开一些网页不仅emacs没有获得焦点，还看不到eaf，需要改变一下window布局才会正常显示eaf。