### PR TITLE
Fix typo

### DIFF
--- a/install-eaf.sh
+++ b/install-eaf.sh
@@ -28,7 +28,7 @@ elif dnf &> /dev/null; then
 elif type pacman &> /dev/null; then
     sudo pacman -Sy --noconfirm --needed "${ARCH_PACKAGES[@]}"
     if type yay &> /dev/null; then
-        yay -Sc --noconfirm filebrowser-bin
+        yay -S --noconfirm filebrowser-bin
     fi
 else
     echo "Unsupported distribution/package manager. Here are the packages that needs to be installed:"


### PR DESCRIPTION
The current command, `yay -Sc --noconfirm filebrowser-bin` does not do what it intends. The `-Sc` means clean local cache, and ignores the `filebrowser-bin` part. What it actually do is identical to `yay -Sc --noconfirm`, which deletes all my yay cache without asking. This is a VERY RUDE behavior.