### PR TITLE
fix zoom factor when url changed

### DIFF
--- a/core/browser.py
+++ b/core/browser.py
@@ -688,9 +688,9 @@ class BrowserBuffer(Buffer):
         self.build_interactive_method(self.buffer_widget, "back", "history_backward", insert_or_do=True)
         self.build_interactive_method(self.buffer_widget, "forward", "history_forward", insert_or_do=True)
 
-        # Reset to default zoom when page init or page url changed.
+        # Reset to default zoom when page init or load finished.
         self.reset_default_zoom()
-        self.buffer_widget.urlChanged.connect(lambda url: self.reset_default_zoom())
+        self.buffer_widget.loadFinished.connect(lambda _: self.reset_default_zoom())
 
     def notify_print_message(self, file_path, success):
         ''' Notify the print as pdf message.'''


### PR DESCRIPTION
当切换url的时候，原来在urlChanged里面处理zoomFactor会不生效，改成loadFinished之后，效果符合预期。
我这儿的环境是
```
PyQt5==5.15.2
PyQt5-sip==12.8.1
PyQtWebEngine==5.15.2
```
不太确定是我这儿的环境问题还是确实存在问题。
参看
https://stackoverflow.com/questions/36518896/zoom-feature-for-qwebengine-does-not-work
https://bugreports.qt.io/browse/QTBUG-51992?gerritIssueType=IssueOnly