### PR TITLE
Readme typo: extraneous parentheses in Quelpa recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ git clone --depth=1 -b master https://github.com/manateelazycat/emacs-applicatio
 
 Alternatively, you can use a [Quelpa recipe](https://github.com/quelpa/quelpa)
 ```Emacs-lisp
-(quelpa '(eaf (:fetcher github
-               :repo  "manateelazycat/emacs-application-framework"
-               :files ("*"))))
+(quelpa '(eaf :fetcher github
+              :repo  "manateelazycat/emacs-application-framework"
+              :files ("*")))
 ```
 
 2. Install EAF dependencies using `M-x eaf-install-dependencies`.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -65,9 +65,9 @@ git clone --depth=1 -b master https://github.com/manateelazycat/emacs-applicatio
 
 你也可以通过[Quelpa](https://github.com/quelpa/quelpa)来下载
 ```Emacs-lisp
-(quelpa '(eaf (:fetcher github
-               :repo  "manateelazycat/emacs-application-framework"
-               :files ("*"))))
+(quelpa '(eaf :fetcher github
+              :repo  "manateelazycat/emacs-application-framework"
+              :files ("*")))
 ```
 
 2. 通过`M-x eaf-install-dependencies`安装EAF依赖，


### PR DESCRIPTION
The current Quelpa expression in the readme fails with a pretty confusing error, because of one too many pair of parentheses.