### PR TITLE
Improve markers.js on bing.com and weiyun.com

### DIFF
--- a/core/js/marker.js
+++ b/core/js/marker.js
@@ -47,7 +47,7 @@ try {
     }
 
     function isElementClickable(e) {
-        let clickSelectors = "a, button, select, input, textarea, summary, *[onclick], *[contenteditable=true], *.jfk-button, *.goog-flat-menu-button, *[role=button], *[role=link], *[role=menuitem], *[role=option], *[role=switch], *[role=tab], *[role=checkbox], *[role=combobox], *[role=menuitemcheckbox], *[role=menuitemradio], *.collapsed, *.expanded";
+        let clickSelectors = "a, button, select, input, textarea, summary, *[onclick], *[contenteditable=true], *.jfk-button, *.goog-flat-menu-button, *[role=button], *[role=link], *[role=menuitem], *[role=option], *[role=switch], *[role=tab], *[role=checkbox], *[role=combobox], *[role=menuitemcheckbox], *[role=menuitemradio], *.collapsed, *.expanded, *.est_unselected, *.tab, *.mod-action-wrap, *.menu-item";
 
         return e.matches(clickSelectors) || getComputedStyle(e).cursor.substr(0, 4) === "url(";
     }


### PR DESCRIPTION
@MatthewZMD I have added several selectors to
make some links on cn.bing.com and weiyun.com clickable for eaf browser.
It's not perfect. Help wanted!

I notice that some codes in markders.js are from surfingkeys.
However, it is not as powerful as surfingkeys. The added selectors are
unnecessar for surfingkeys. I don't know why. I'm new to Javascript and
have not read through marker.js. Please have a look at this issue.
