### PR TITLE
fix the hiding of eaf browser buffer's view on Windows

### DIFF
--- a/eaf.el
+++ b/eaf.el
@@ -1658,6 +1658,8 @@ WEBENGINE-INCLUDE-PRIVATE-CODEC is only useful when app-name is video-player."
 
 (defun eaf--update-buffer-details (buffer-id title url)
   "Function for updating buffer details with its BUFFER-ID, TITLE and URL."
+  (when (eaf--called-from-wsl-on-windows-p)
+    (eaf-monitor-configuration-change))
   (when (> (length title) 0)
     (catch 'found-eaf
       (dolist (window (window-list))


### PR DESCRIPTION
Eaf browser buffer's view hides sometimes when the eaf on Windows is called by
emacs on WSL. Eaf browser runs well but on the background and we can't see it.
Apparently, the reparent doesn't work correctly for some reason. The workaround
for now is to call eaf-monitor-configuration-change to make the eaf browser
buffer's view appear.