### PR TITLE
Don't use empty filename for newly mindmap

### DIFF
--- a/app/mindmap/buffer.py
+++ b/app/mindmap/buffer.py
@@ -88,7 +88,7 @@ class AppBuffer(BrowserBuffer):
             color = "#242525"
         self.buffer_widget.eval_js("init_background('{}');".format(color))
 
-        self.change_title(self.get_root_node_topic())
+        self.change_title(self.get_title())
 
     def build_js_method(self, method_name, auto_save=False, js_kwargs=None):
         js_kwargs = js_kwargs or {}
@@ -114,7 +114,7 @@ class AppBuffer(BrowserBuffer):
                 color = "#242525"
             self.buffer_widget.eval_js("init_background('{}');".format(color))
 
-            self.change_title(self.get_root_node_topic())
+            self.change_title(self.get_title())
 
     @interactive(insert_or_do=True)
     def change_background_color(self):
@@ -172,7 +172,7 @@ class AppBuffer(BrowserBuffer):
     def handle_update_node_topic(self, topic):
         self.buffer_widget.eval_js("update_node_topic('{}');".format(escape(topic)))
 
-        self.change_title(self.get_root_node_topic())
+        self.change_title(self.get_title())
 
         self.save_file(False)
 
@@ -226,6 +226,9 @@ class AppBuffer(BrowserBuffer):
 
     def is_focus(self):
         return self.buffer_widget.execute_js("node_is_focus();")
+
+    def get_title(self):
+        return os.path.basename(self.url) or self.get_root_node_topic()
 
     def get_root_node_topic(self):
         return self.buffer_widget.execute_js("get_root_node_topic();")

--- a/eaf.el
+++ b/eaf.el
@@ -2215,14 +2215,11 @@ Make sure that your smartphone is connected to the same WiFi network as this com
     (local-set-key (kbd "C-c C-k") 'eaf-edit-buffer-cancel)
     (eaf--edit-set-header-line)))
 
-(defun eaf-create-mindmap ()
-  "Create a new Mindmap file."
-  (interactive)
-  (eaf-open " " "mindmap"))
+(defalias 'eaf-create-mindmap 'eaf-open-mindmap)  ;; compatible
 
 (defun eaf-open-mindmap (file)
   "Open a given Mindmap FILE."
-  (interactive "f[EAF/mindmap] Select Mindmap file: ")
+  (interactive "F[EAF/mindmap] Select Mindmap file: ")
   (eaf-open file "mindmap"))
 
 (defun eaf-get-file-md5 (file)


### PR DESCRIPTION
Use " " as filename will create many random files caused by *auto save*, and also we can't rename the buffer. So specify the filename when creation should be better.