### PR TITLE
Fix the bug caused by eaf--active-buffers being non-nil.

### DIFF
--- a/eaf.el
+++ b/eaf.el
@@ -1665,7 +1665,8 @@ WEBENGINE-INCLUDE-PRIVATE-CODEC is only useful when app-name is video-player."
     (eaf--open-internal first-start-url first-start-app-name first-start-args))
 
   (dolist (buffer-info eaf--active-buffers)
-    (eaf--open-internal (nth 0 buffer-info) (nth 1 buffer-info) (nth 2 buffer-info))))
+    (eaf--open-internal (nth 0 buffer-info) (nth 1 buffer-info) (nth 2 buffer-info)))
+  (setq eaf--active-buffers nil))
 
 (defun eaf--update-buffer-details (buffer-id title url)
   "Function for updating buffer details with its BUFFER-ID, TITLE and URL."


### PR DESCRIPTION
If we dont't eaf--active-buffers to nil after eaf--first-start, it may remain to be non-nil when we use this variable again when calling eaf-open, and the parameter of eaf-open won't be push into eaf--active-buffers, therefore not opening the correct url.