### PR TITLE
Make sure load finished before initialize

### DIFF
--- a/app/mindmap/buffer.py
+++ b/app/mindmap/buffer.py
@@ -61,7 +61,7 @@ class AppBuffer(BrowserBuffer):
 
         self.build_all_methods(self)
 
-        QTimer.singleShot(500, self.initialize)
+        self.buffer_widget.loadFinished.connect(lambda _: self.initialize())
 
     def resize_view(self):
         self.buffer_widget.eval_js("relayout();")


### PR DESCRIPTION
Sometimes index.html not load finished, then js functions like `open_file`, `init_background` evaluated in `initialize` will failed, and the mindmap open failed.