### PR TITLE
Add EXWM to default eaf-wm-focus-fix-wms variable

### DIFF
--- a/eaf.el
+++ b/eaf.el
@@ -831,6 +831,7 @@ Then EAF will start by gdb, please send new issue with `*eaf*' buffer content wh
     "i3"                                ;i3
     "LG3D"                              ;qtile
     "Xpra"
+    "EXWM"
     )
   "Set mouse cursor to frame bottom in these wms, to make EAF receive input event.
 Add NAME of command `wmctrl -m' to this list."


### PR DESCRIPTION
EXWM doesn't work out of the box, but adding to this variable seems to fix the issue (tested with the EAF browser).

This proposed change is discussed in #47.