### PR TITLE
Make install-eaf.sh run in eaf directory

### DIFF
--- a/eaf.el
+++ b/eaf.el
@@ -86,13 +86,15 @@
 (defun eaf-install-dependencies ()
   "An interactive function that run install-eaf.sh or install-eaf-win32.js or install-eaf-mac.sh for Linux or Windows or macOS respectively."
   (interactive)
-  (let ((eaf-dir (file-name-directory (locate-library "eaf"))))
+  (let* ((eaf-dir (file-name-directory (locate-library "eaf")))
+         (default-directory eaf-dir))
     (cond ((eq system-type 'gnu/linux)
-           (shell-command (concat eaf-dir "install-eaf.sh" "&")))
+           (shell-command (concat "./install-eaf.sh" "&")))
           ((memq system-type '(cygwin windows-nt ms-dos))
            (shell-command (format "node %s" (concat eaf-dir "install-eaf-win32.js" "&"))))
           ((eq system-type 'darwin)
-           (shell-command (concat eaf-dir "install-eaf-mac.sh" "&"))))))
+           (shell-command (concat "./install-eaf-mac.sh" "&"))))))
+
 
 (require 'bookmark)
 (require 'cl-lib)


### PR DESCRIPTION
The install-eaf.sh script should run in the eaf directory. This commit fixes that for linux and osx. As I can not test on Windows, I have not touched that command.

btw. the npm install errors with the following message (although the browser still works):
```
 ERROR  Failed to compile with 2 errors                                                                                                                                                                                            10:19:22 AM

This dependency was not found:

* @fortawesome/fontawesome-svg-core in ./node_modules/@fortawesome/vue-fontawesome/index.es.js, ./src/main.js
```
Let me know if I should open an issue for this, and if you need more information about it. I am on Fedora 34.