### PR TITLE
check node/npm installation status on ubuntu before install it.

### DIFF
--- a/install-eaf.sh
+++ b/install-eaf.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -eu
 
@@ -10,7 +10,17 @@ python-qrcode aria2 python-qtconsole taglib"
 if [ "$(command -v apt)" ]; then
     # Missing in Ubuntu: filebrowser-bin
     # shellcheck disable=SC2015
-    sudo apt -y install git nodejs npm aria2 wmctrl &&
+    DEPS=("git" "aria2" "wmctrl")
+
+    if ! command -v node &> /dev/null; then
+        DEPS+=("nodejs")
+    fi
+
+    if ! command -v npm &> /dev/null; then
+        DEPS+=("npm")
+    fi
+
+    sudo apt -y install "${DEPS[@]}" &&
         sudo apt -y install libglib2.0-dev &&
         sudo apt -y install python3-pyqt5 python3-sip python3-pyqt5.qtwebengine \
              python3-qrcode python3-feedparser \

--- a/install-eaf.sh
+++ b/install-eaf.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 set -eu
 


### PR DESCRIPTION
Ubuntu has some deps issues if node is installed with node source
repoistory. check command is exists before apt install.

This is a workaround for npm deps issue if it had been installed manually.

see #666 