### PR TITLE
Add get_select function for pdf-viewer

### DIFF
--- a/app/pdf-viewer/buffer.py
+++ b/app/pdf-viewer/buffer.py
@@ -150,6 +150,14 @@ class AppBuffer(Buffer):
         else:
             message_to_emacs("Cannot copy, you should double click your mouse and hover through the text on the PDF. Don't click and drag!")
 
+    def get_select(self):
+        if self.buffer_widget.is_select_mode:
+            content = self.buffer_widget.parse_select_char_list()
+            self.buffer_widget.cleanup_select()
+            return content
+        else:
+            return ""
+
     def page_total_number(self):
         return str(self.buffer_widget.page_total_number)
 


### PR DESCRIPTION
This adds `get_select` function for pdf-viewer, it simply returns the selected text to elisp side, so that user can use 
```
(eaf-call-sync "call_function" eaf--buffer-id "get_select")
```
to get then clear the text.