### PR TITLE
pdf viewer support trim white margin

### DIFF
--- a/app/pdf-viewer/buffer.py
+++ b/app/pdf-viewer/buffer.py
@@ -366,6 +366,8 @@ class PdfPage(fitz.Page):
             x1 = max(x1, r.x1)
             y1 = max(y1, r.y1)
             r = fitz.Rect(x0, y0, x1, y1)
+        if r is None:
+            return self.page.CropBox
         return r
 
     def get_tight_margin_rect(self):

--- a/app/pdf-viewer/buffer.py
+++ b/app/pdf-viewer/buffer.py
@@ -293,7 +293,7 @@ class PdfDocument(fitz.Document):
                 # Some program will generate `middle` file, but file already changed, fitz try to
                 # open the `middle` file caused error.
                 time.sleep(0.1)
-                self.reload_document(path)
+                self.reload_document(path, self._page_clip)
             except:
                 return
 

--- a/eaf.el
+++ b/eaf.el
@@ -352,6 +352,7 @@ It must defined at `eaf-browser-search-engines'."
     (eaf-pdf-default-zoom . "1.0")
     (eaf-pdf-dark-exclude-image . "true")
     (eaf-pdf-scroll-ratio . "0.05")
+    (eaf-pdf-enable-trim-white-margin . "false")
     (eaf-terminal-dark-mode . "follow")
     (eaf-terminal-font-size . "13")
     (eaf-terminal-font-family . "")

--- a/eaf.el
+++ b/eaf.el
@@ -556,7 +556,8 @@ Try not to modify this alist directly.  Use `eaf-setq' to modify instead."
     ("M-p" . "toggle_presentation_mode")
     ("J" . "select_left_tab")
     ("K" . "select_right_tab")
-    ("o" . "eaf-pdf-outline"))
+    ("o" . "eaf-pdf-outline")
+    ("T" . "toggle_trim_white_margin"))
   "The keybinding of EAF PDF Viewer."
   :type 'cons)
 


### PR DESCRIPTION
Current implement this feature will cause load page slow, so default is disable this feature. #662