### PR TITLE
fix a problem introduced in pr #698

### DIFF
--- a/eaf.el
+++ b/eaf.el
@@ -240,7 +240,7 @@ been initialized."
           epcs:server-processes)
     main-process))
 
-(defvar eaf-server
+(defun eaf--start-epc-server ()
   (let (server)
     (setq server (epcs:server-start
                   (lambda (mngr)
@@ -259,9 +259,10 @@ been initialized."
                   ))
     (if server
         (setq eaf-server-port (process-contact server :service))
-      (message "eaf-server fails to start.")
+      (error "eaf-server fails to start.")
       )
-    server))
+    server)
+  )
 
 (when noninteractive
   ;; Start "event loop".
@@ -1182,6 +1183,8 @@ A hashtable, key is url and value is title.")
     (user-error "[EAF] Please initiate EAF with eaf-open-... functions only"))
    ((epc:live-p eaf-epc-process)
     (user-error "[EAF] Process is already running")))
+  ;; start epc server and set `eaf-server-port'
+  (eaf--start-epc-server)
   (let* ((eaf-args (append
                     (list eaf-python-file)
                     (eaf-get-render-size)

--- a/eaf.el
+++ b/eaf.el
@@ -240,28 +240,30 @@ been initialized."
           epcs:server-processes)
     main-process))
 
+(defvar eaf-server nil)
 (defun eaf--start-epc-server ()
-  (let (server)
-    (setq server (epcs:server-start
-                  (lambda (mngr)
-                    (let ((mngr mngr))
-                      (epc:define-method
-                       mngr 'eval-in-emacs
-                       (lambda (&rest args)
-                         ;; Decode argument with Base64 format automatically.
-                         (apply (read (car args))
-                                (mapcar
-                                 (lambda (arg)
-                                   (let ((arg (eaf--decode-string arg)))
-                                     (cond ((string-prefix-p "'" arg)
-                                            (read (substring arg 1)))
-                                           (t arg)))) (cdr args)))))))
-                  ))
-    (if server
-        (setq eaf-server-port (process-contact server :service))
+  (unless eaf-server
+    (setq eaf-server (epcs:server-start
+                      (lambda (mngr)
+                        (let ((mngr mngr))
+                          (epc:define-method
+                           mngr 'eval-in-emacs
+                           (lambda (&rest args)
+                             ;; Decode argument with Base64 format automatically.
+                             (apply (read (car args))
+                                    (mapcar
+                                     (lambda (arg)
+                                       (let ((arg (eaf--decode-string arg)))
+                                         (cond ((string-prefix-p "'" arg)
+                                                (read (substring arg 1)))
+                                               (t arg)))) (cdr args)))))))
+                      ))
+    (if eaf-server
+        (setq eaf-server-port (process-contact eaf-server :service))
       (error "eaf-server fails to start.")
       )
-    server)
+    )
+  eaf-server
   )
 
 (when noninteractive


### PR DESCRIPTION
Sorry that in #698 a problem in introduced, which is every time when EAF starts after a termination, a new epc server will be created. 

每次当所有的EAF  buffer都被kill了之后，EAF 进程会终止。下次再打开EAF buffer时会再启动一个EAF进程。#698 会导致EAF进程每启动一次就会生成一个epc server。

不好意思，#698 测试的不够充分，没有发现这个问题。