### PR TITLE
Fix terminal cwd when startup

### DIFF
--- a/app/terminal/buffer.py
+++ b/app/terminal/buffer.py
@@ -45,7 +45,7 @@ class AppBuffer(BrowserBuffer):
 
         arguments_dict = json.loads(arguments)
         self.command = arguments_dict["command"]
-        self.start_directory = arguments_dict["directory"]
+        self.start_directory = arguments_dict["directory"].rstrip('/')
         self.current_directory = self.start_directory
         self.executing_command = ""
         self.index_file = "{0}/index.html".format(self.http_url)


### PR DESCRIPTION
When used with zsh&oh-my-zsh, start terminal app, it will show like
```
➜   git:(master) 
```
where the current directory name is missing.
