### PR TITLE
Fix browser caret bug caused by commit e162955

### DIFF
--- a/core/webengine.py
+++ b/core/webengine.py
@@ -883,7 +883,7 @@ class BrowserBuffer(Buffer):
                 self.buffer_widget.eval_js("CaretBrowsing.setInitialCursor();")
                 message_to_emacs("Caret browsing activated.")
                 self.caret_browsing_mode = True
-                eval_in_emacs('eaf--toggle-caret-browsing', ["'t" if self.caret_browsing_mode else "'nil"])
+            eval_in_emacs('eaf--toggle-caret-browsing', ["'t" if self.caret_browsing_mode else "'nil"])
 
     def caret_exit(self):
         ''' Exit caret browsing.'''


### PR DESCRIPTION
* Bug description:
Once we get into `browse-caret-mode`, then we can't quit this mode.
Specifically, we can't use j and k to scroll up and down when we can't
quit this mode.

* Other words:
Actually, this is a very simple bug, which is merely caused by
mistaken indent when manateelazycat solve other issues.

And I noticed there are other changes on indent, such as at line 116,
1080 and 1242 of `webengine.py` file in commit e162955. but I can't
understand these lines. So I didn't changes these lines. I just want
to notice if there are something messed up too!

By the way, this is my first time to do a PR, and I am not good at
english, So if there are some nonstandard expressions and wrong
english grammar, I'm very sorry about that!