### PR TITLE
core: transfer first key event to buffer

### DIFF
--- a/core/view.py
+++ b/core/view.py
@@ -126,6 +126,12 @@ class View(QWidget):
             # Stop mouse event.
             return True
 
+        # Transfer the key event to buffer widget.
+        if event.type() == QEvent.KeyPress:
+            self.buffer.fake_key_event(event.text())
+            # Stop key event.
+            return True
+
         return False
 
     def showEvent(self, event):


### PR DESCRIPTION
当将emacs切换到其他应用，再切换回来，如果鼠标在EAF的区域内，会导致第一个按键事件丢失。

注： 在KDE环境下。