### PR TITLE
core: transfer first key to emacs

### DIFF
--- a/core/view.py
+++ b/core/view.py
@@ -27,6 +27,24 @@ from core.utils import eval_in_emacs, focus_emacs_buffer
 import platform
 import os
 
+emacs_key_dict = {
+    Qt.Key_Space: '''SPC''',
+    Qt.Key_Return: '''RET''',
+    Qt.Key_Backspace: '''DEL''',
+    Qt.Key_Tab: '''TAB''',
+    Qt.Key_Backtab: '''<backtab>''',
+    Qt.Key_Home: '''<home>''',
+    Qt.Key_End: '''<end>''',
+    Qt.Key_Left: '''<left>''',
+    Qt.Key_Right: '''<right>''',
+    Qt.Key_Up: '''<up>''',
+    Qt.Key_Down: '''<down>''',
+    Qt.Key_PageUp: '''<prior>''',
+    Qt.Key_PageDown: '''<next>''',
+    Qt.Key_Delete: '''<delete>'''
+}
+
+
 class View(QWidget):
 
     def __init__(self, buffer, view_info):
@@ -128,7 +146,8 @@ class View(QWidget):
 
         # Transfer the key event to buffer widget.
         if event.type() == QEvent.KeyPress:
-            self.buffer.fake_key_event(event.text())
+            args = [emacs_key_dict.get(event.key(), event.text())]
+            eval_in_emacs("eaf-read-key", args)
             # Stop key event.
             return True
 
@@ -137,7 +156,7 @@ class View(QWidget):
     def showEvent(self, event):
         # NOTE: we must reparent after widget show, otherwise reparent operation maybe failed.
         self.reparent()
-        
+
         if platform.system() in ["Windows", "Darwin"]:
             eval_in_emacs('eaf-activate-emacs-window', [])
 

--- a/eaf.el
+++ b/eaf.el
@@ -1542,6 +1542,11 @@ Including title-bar, menu-bar, offset depends on window system, and border."
   (eaf-call-async "action_quit" eaf--buffer-id)
   (call-interactively 'keyboard-quit))
 
+(defun eaf-read-key (key)
+  "Read `KEY' from EAF Python side."
+  (setq unread-command-events
+        (append (apply 'vconcat (mapcar 'kbd (list key))) nil)))
+
 (defun eaf-send-key ()
   "Directly send key to EAF Python side."
   (interactive)


### PR DESCRIPTION
#727 中只能处理没有在emacs中设置key-binding的按键，所以之前在 *terminal* 这样的应用中效果是对的，但是在 *browser* 中按 *j*, *k* 这样的快捷键是不对的。

现在将对应的按键事件发送到emacs, 这样保持和 *正常* 按键处理流程一致。