### PR TITLE
pdf-viewer: A more useful mode line position indicator.

### DIFF
--- a/app/pdf-viewer/buffer.py
+++ b/app/pdf-viewer/buffer.py
@@ -26,7 +26,7 @@ from PyQt5.QtGui import QPainter
 from PyQt5.QtWidgets import QWidget
 from PyQt5.QtWidgets import QToolTip
 from core.buffer import Buffer
-from core.utils import touch, interactive, eval_in_emacs, message_to_emacs, open_url_in_new_tab, translate_text, atomic_edit
+from core.utils import touch, interactive, eval_in_emacs, set_emacs_var, message_to_emacs, open_url_in_new_tab, translate_text, atomic_edit
 import fitz
 import time
 import random
@@ -1335,6 +1335,9 @@ class PdfViewerWidget(QWidget):
         if self.scroll_offset != new_offset:
             self.scroll_offset = new_offset
             self.update()
+            page_index = self.start_page_index + 1
+            set_emacs_var('eaf-pdf-current-page', page_index, False)
+            eval_in_emacs('run-hooks', ["\'eaf-pdf-scroll-hook"])
 
     def update_horizontal_offset(self, new_offset):
         if self.horizontal_offset != new_offset:

--- a/app/pdf-viewer/eaf-pdf-viewer.el
+++ b/app/pdf-viewer/eaf-pdf-viewer.el
@@ -95,7 +95,7 @@
 
 Set by Python's page_total_number function.")
 
-(defvar-local eaf-pdf-current-page nil
+(defvar-local eaf-pdf-current-page "??"
   "The current page of this pdf-viewer app.
 
 Set by Python's update_vertical_offset function every time user scrolls.")

--- a/app/pdf-viewer/eaf-pdf-viewer.el
+++ b/app/pdf-viewer/eaf-pdf-viewer.el
@@ -90,6 +90,11 @@
 (defvar eaf-pdf-outline-window-configuration nil
   "Save window configure before popup outline buffer.")
 
+(defvar-local eaf-pdf-total-page nil
+  "The total page of this pdf-viewer app.
+
+Set by Python's page_total_number function.")
+
 (defvar-local eaf-pdf-current-page nil
   "The current page of this pdf-viewer app.
 
@@ -114,6 +119,19 @@ Set by Python's update_vertical_offset function every time user scrolls.")
             (define-key map (kbd "RET") 'eaf-pdf-outline-jump)
             (define-key map (kbd "q") 'quit-window)
             map))
+
+(defun eaf-pdf-format-mode-line-position ()
+  "Format the line position indicator in mode line to indicate CURRENT-PAGE/TOTAL-PAGE."
+  (setq-local mode-line-position
+              '(" P" eaf-pdf-current-page
+                ;; Avoid errors during redisplay.
+                "/" (:eval (or eaf-pdf-total-page
+                               (setq-local
+                                eaf-pdf-total-page
+                                (eaf-call-sync "call_function"
+                                               eaf--buffer-id "page_total_number")))))))
+
+(add-hook 'eaf-pdf-viewer-hook #'eaf-pdf-format-mode-line-position)
 
 (defun eaf-pdf-outline ()
   "Create PDF outline."

--- a/app/pdf-viewer/eaf-pdf-viewer.el
+++ b/app/pdf-viewer/eaf-pdf-viewer.el
@@ -90,6 +90,15 @@
 (defvar eaf-pdf-outline-window-configuration nil
   "Save window configure before popup outline buffer.")
 
+(defvar-local eaf-pdf-current-page nil
+  "The current page of this pdf-viewer app.
+
+Set by Python's update_vertical_offset function every time user scrolls.")
+
+(defcustom eaf-pdf-scroll-hook '(force-mode-line-update)
+  "List of Functions to run when user scrolls in pdf-viewer app."
+  :type 'hook)
+
 (defcustom eaf-pdf-extension-list
   '("pdf" "xps" "oxps" "cbz" "epub" "fb2" "fbz")
   "The extension list of pdf application."


### PR DESCRIPTION
The old position indicator always displays `All (1,0)` which is not very useful. This will replace that to display the current page and the total page of the document.

There are two local variables added; `eaf-pdf-current-page` and `eaf-pdf-total-page`,
the current-page variable is set with `set_emacs_var` on the Python's side every time user scrolls.