### PR TITLE
install-eaf.sh: FreeBSD support 

### DIFF
--- a/eaf.el
+++ b/eaf.el
@@ -2146,7 +2146,8 @@ the file at current cursor position in dired."
     (eaf--activate-emacs-win32-window))
    ((eq system-type 'darwin)
     (eaf--activate-emacs-mac-window))
-   ((executable-find "wmctrl")
+   ((or (eq system-type 'gnu/linux)
+        (eq system-type 'berkeley-unix))
     (eaf--activate-emacs-linux-window buffer_id))))
 
 (defun eaf--select-window-by-direction (direction)

--- a/eaf.el
+++ b/eaf.el
@@ -2167,7 +2167,7 @@ the file at current cursor position in dired."
     (eaf--activate-emacs-win32-window))
    ((eq system-type 'darwin)
     (eaf--activate-emacs-mac-window))
-   ((eq system-type 'gnu/linux)
+   ((executable-find "wmctrl")
     (eaf--activate-emacs-linux-window buffer_id))))
 
 (defun eaf--select-window-by-direction (direction)

--- a/install-eaf.sh
+++ b/install-eaf.sh
@@ -67,6 +67,16 @@ elif [ "$(command -v pacman)" ]; then
     sudo pacman -Sy --noconfirm --needed $ARCH_PACKAGES ||
         { echo "[EAF] Failed to install dependency with pacman."; exit 1;}
     [ "$(command -v yay)" ] && yay -S --noconfirm filebrowser-bin
+
+elif [ "$(command -v pkg)" ]; then
+    # shellcheck disable=SC2086
+    # NOTE: No filebrowser-bin, so eaf-open-file-manager won't work!
+    doas pkg install -y node npm wmctrl aria2 &&
+        doas pkg install -y glib &&
+        doas pkg install -y python38 py38-pip py38-qt5-sip py38-qt5-webengine \
+             py38-qrcode py38-qtconsole taglib ||
+            { echo "[EAF] Failed to install dependency with pkg."; exit 1;}
+    
 else
     echo "[EAF] Unsupported distribution/package manager. Here are the packages that needs to be installed:"
     for PCK in $ARCH_PACKAGES; do


### PR DESCRIPTION
Tested on nomadbsd-130R-20210508.amd64 image in a virtual machine.
(nomadBSD is essentially FreeBSD with Xorg preinstalled.)

✓ = Works ? = Unsure ❌ = Error

The ? is either because 
1) I don't know how to use 
or
2) I don't have the software/hardware to test it.

| Launch                                                                 | Results |
|:-----------------------------------------------------------------------|:--------|
| `M-x eaf-open-browser` Search or Goto URL                              | ✓        |
| `M-x eaf-open-browser-with-history` Search or Goto URL or Goto History | ✓        |
| `M-x eaf-open-mail-as-html` in `gnus`, `mu4e`, `notmuch` HTMl Mail     | ?        |
| `M-x eaf-open` PDF File                                                | ❌ `FT_Get_First_Char: symbol not found`, https://github.com/pymupdf/PyMuPDF/issues/1013        |
| `M-x eaf-open` Video File                                              | ✓        |
| `M-x eaf-open` Image File                                              | ✓        |
| `M-x eaf-open` Markdown File                                           | ✓        |
| `M-x eaf-open` Org File                                                | ✓        |
| `M-x eaf-open-camera`                                                  | ?        |
| `M-x eaf-open-terminal`                                                | ✓        |
| `M-x eaf-file-sender-qrcode` or `eaf-file-sender-qrcode-in-dired`      | ?        |
| `M-x eaf-file-browser-qrcode`                                          | ?        |
| `M-x eaf-open-airshare`                                                | ?        |
| `M-x eaf-create-mindmap` or `M-x eaf-open-mindmap`                     | ?        |
| `M-x eaf-open-office`                                                  | ❌ Won't work if pdf-viewer doesn't work       |
| `M-x eaf-open-jupyter`                                                 | ✓        |
| `M-x eaf-open-music-player`                                            | ?        |
| `M-x eaf-open-system-monitor`                                          | ❌ A loop of `js: Uncaught ReferenceError: updatePanelInfo is not defined`
| `M-x eaf-open-demo` to verify basic functionality                      | ✓        |
| `M-x eaf-open-vue-demo` to verify vue.js functionality                 | ✓        |

