### PR TITLE
clear both searched text and selected text at the same time by quit-action

### DIFF
--- a/core/webengine.py
+++ b/core/webengine.py
@@ -32,6 +32,7 @@ from functools import partial
 from urllib.parse import urlparse, parse_qs, urlunparse, urlencode
 import base64
 import os
+import time
 import platform
 import sqlite3
 
@@ -190,6 +191,8 @@ class BrowserView(QWebEngineView):
         ''' Quit action.'''
         if self.search_term != "":
             self._search_text("")
+            time.sleep(0.1)
+
         if self.buffer.caret_browsing_mode:
             if self.buffer.caret_browsing_mark_activated:
                 self.buffer.caret_toggle_mark()
@@ -198,8 +201,7 @@ class BrowserView(QWebEngineView):
 
         # Need wrap hasSelection, otherwise close web page will cause webengine crash.
         try:
-            if self.web_page.hasSelection():
-                self.triggerPageAction(self.web_page.Unselect)
+            self.triggerPageAction(self.web_page.Unselect)
         except:
             pass
 


### PR DESCRIPTION
Hi,

This is a small tweak to `C-g` to cleared both searched text and selected text at the same time.

The current behavior of webengine is that when a user searches a text using
`C-s` and then presses `C-g` to quit, then the current searched text will still
highlighted (by the selection mode), while other nearby searched texts are cleared.

So, the user needs to press `C-g` again to clear that current searched text.

I put a timeout of 0.1s to wait for the current searched text to be highlighted,
then the next code will clear it:

``` python
        try:
            self.triggerPageAction(self.web_page.Unselect)
        except:
            pass
```

In the above code, I remove the condition `if self.web_page.hasSelection()`
since it is wrapped by the exception checking anyway, so that condition isn't
needed.

Can you review and consider if it can be merged?

Thanks!

