### PR TITLE
Fix issue #1040.

### DIFF
--- a/eaf.el
+++ b/eaf.el
@@ -829,8 +829,9 @@ We need calcuate render allocation to make sure no black border around render co
   (let* ((window-edges (window-pixel-edges window))
          (x (nth 0 window-edges))
          (y (+ (nth 1 window-edges)
+               (window-header-line-height window)
                (if (version< emacs-version "27.0")
-                   (window-header-line-height window)
+                   0
                  (window-tab-line-height window))))
          (w (- (nth 2 window-edges) x))
          (h (- (nth 3 window-edges) (window-mode-line-height window) y)))


### PR DESCRIPTION
I think this issue was introduced by the commit b3de6d38e395867895c1030efbdd46f75f2a1f58.

In fact I can not understand that commit. The header line still works well after the tab line was introduced in Emacs 27.0 version. Why it put `window-header-line-height` and `window-tab-line-height` in a mutually exclusive position?