### PR TITLE
Fix wrong usage of "eval-when-compile".

### DIFF
--- a/eaf.el
+++ b/eaf.el
@@ -1050,7 +1050,7 @@ Including title-bar, menu-bar, offset depends on window system, and border."
       (+ (eaf--frame-top frame) (eaf--frame-internal-height frame))
     0))
 
-(eval-when-compile
+(eval-and-compile
 
   (defun eaf-emacs-not-use-reparent-technology ()
     "When Emacs running in macOS、Wayland native or terminal environment,


### PR DESCRIPTION
The usage of `eval-when-compile` is wrong here. If you really do byte-compile (or do native-compile further) and load the compiled file at run time, you will find that the `add-hook` and `add-to-list` do not work. In fact they only work at compile time and change the compilation environment, not at run time. use `eval-and-compile` can fix that problem.