### PR TITLE
Raise exception when command not found and when ensure_pass is True

### DIFF
--- a/install-eaf.py
+++ b/install-eaf.py
@@ -77,8 +77,8 @@ def run_command(command, path=script_path, ensure_pass=True, get_result=False):
 
     # Throw exception if command not found,
     # We found install-eaf.py still can work even it not found npm in system.
-    if not which(command[0]):
-        return Exception(f"Not found command: {command[0]}")
+    if (not which(command[0])) and ensure_pass:
+        raise Exception(f"Not found command: {command[0]}")
 
     # Use LC_ALL=C to make sure command output use English.
     # Then we can use English keyword to check command output.


### PR DESCRIPTION
If the command is not found, the exception is not raised, but instead returned, which leads to the exception not being logged and the installation silently failing; the end result will be a bad/partial installation yet the user will receive no information about it until they try and run an eaf application. 